### PR TITLE
Add web FAB to center map

### DIFF
--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -232,15 +232,41 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
         children: [
           SizedBox(
             height: 300,
-            child: GoogleMap(
-              onMapCreated: _onMapCreated,
-              initialCameraPosition: CameraPosition(
-                target: initialMapPos,
-                zoom: 13,
-              ),
-              myLocationEnabled: false,
-              markers: _buildMarkers(),
-              circles: _buildRadiusCircles(),
+            child: Stack(
+              children: [
+                GoogleMap(
+                  onMapCreated: _onMapCreated,
+                  initialCameraPosition: CameraPosition(
+                    target: initialMapPos,
+                    zoom: 13,
+                  ),
+                  myLocationEnabled: !kIsWeb,
+                  myLocationButtonEnabled: !kIsWeb,
+                  markers: _buildMarkers(),
+                  circles: _buildRadiusCircles(),
+                ),
+                if (kIsWeb)
+                  Positioned(
+                    bottom: 16,
+                    right: 16,
+                    child: FloatingActionButton(
+                      heroTag: 'center_map',
+                      onPressed: () {
+                        if (currentPosition != null) {
+                          mapController?.animateCamera(
+                            CameraUpdate.newLatLng(
+                              LatLng(
+                                currentPosition!.latitude,
+                                currentPosition!.longitude,
+                              ),
+                            ),
+                          );
+                        }
+                      },
+                      child: const Icon(Icons.my_location),
+                    ),
+                  ),
+              ],
             ),
           ),
           Padding(


### PR DESCRIPTION
## Summary
- show `myLocation` features when not on web
- provide a manual center-map button for the web

## Testing
- `./flutter/bin/flutter analyze` *(fails: The current Flutter SDK version is 0.0.0-unknown)*
- `./flutter/bin/flutter test` *(fails: The current Flutter SDK version is 0.0.0-unknown)*

------
https://chatgpt.com/codex/tasks/task_e_6877aa456570832f83158611e67ed88d