### PR TITLE
Add messaging navigation

### DIFF
--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -5,6 +5,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:skiptow/pages/create_invoice_page.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'invoices_page.dart';
+import 'messages_page.dart';
 
 class CustomerDashboard extends StatefulWidget {
   final String userId;
@@ -234,6 +235,46 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
     }
   }
 
+  void _openMessages() {
+    final controller = TextEditingController();
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Enter Recipient ID'),
+          content: TextField(
+            controller: controller,
+            decoration: const InputDecoration(labelText: 'User ID'),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                final otherId = controller.text.trim();
+                if (otherId.isNotEmpty) {
+                  Navigator.pop(context);
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => MessagesPage(
+                        currentUserId: widget.userId,
+                        otherUserId: otherId,
+                      ),
+                    ),
+                  );
+                }
+              },
+              child: const Text('Chat'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -251,6 +292,11 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
                 ),
               );
             },
+          ),
+          IconButton(
+            icon: const Icon(Icons.mail),
+            tooltip: 'Messages',
+            onPressed: _openMessages,
           ),
         ],
       ),

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -6,6 +6,7 @@ import 'package:permission_handler/permission_handler.dart';
 import 'dart:async';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'invoices_page.dart';
+import 'messages_page.dart';
 
 BitmapDescriptor? wrenchIcon;
 
@@ -221,6 +222,46 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
     }
   }
 
+  void _openMessages() {
+    final controller = TextEditingController();
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Enter Recipient ID'),
+          content: TextField(
+            controller: controller,
+            decoration: const InputDecoration(labelText: 'User ID'),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                final otherId = controller.text.trim();
+                if (otherId.isNotEmpty) {
+                  Navigator.pop(context);
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => MessagesPage(
+                        currentUserId: widget.userId,
+                        otherUserId: otherId,
+                      ),
+                    ),
+                  );
+                }
+              },
+              child: const Text('Chat'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final LatLng initialMapPos = currentPosition != null
@@ -242,6 +283,11 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                 ),
               );
             },
+          ),
+          IconButton(
+            icon: const Icon(Icons.mail),
+            tooltip: 'Messages',
+            onPressed: _openMessages,
           ),
         ],
       ),

--- a/lib/pages/messages_page.dart
+++ b/lib/pages/messages_page.dart
@@ -76,7 +76,13 @@ class _MessagesPageState extends State<MessagesPage> {
     }
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Messages')),
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: const Text('Messages'),
+      ),
       body: Column(
         children: [
           Expanded(


### PR DESCRIPTION
## Summary
- import messages page in dashboards
- add `_openMessages` dialog for entering recipient user ID
- add envelope icon to open messages page with IDs passed
- add back button to messages page

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e6325224832fa0e53b2db39a5ed8