### PR TITLE
Implement auto-scroll in MessagesPage

### DIFF
--- a/lib/pages/messages_page.dart
+++ b/lib/pages/messages_page.dart
@@ -17,6 +17,7 @@ class MessagesPage extends StatefulWidget {
 
 class _MessagesPageState extends State<MessagesPage> {
   final TextEditingController _controller = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
   String? _conversationId;
 
   @override
@@ -65,6 +66,24 @@ class _MessagesPageState extends State<MessagesPage> {
     });
 
     _controller.clear();
+    _scrollToBottom();
+  }
+
+  void _scrollToBottom() {
+    if (_scrollController.hasClients) {
+      _scrollController.animateTo(
+        _scrollController.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _scrollController.dispose();
+    super.dispose();
   }
 
   @override
@@ -99,7 +118,10 @@ class _MessagesPageState extends State<MessagesPage> {
                 }
 
                 final docs = snapshot.data!.docs;
+                WidgetsBinding.instance
+                    .addPostFrameCallback((_) => _scrollToBottom());
                 return ListView.builder(
+                  controller: _scrollController,
                   padding: const EdgeInsets.all(8),
                   itemCount: docs.length,
                   itemBuilder: (context, index) {


### PR DESCRIPTION
## Summary
- add a `ScrollController` to `_MessagesPageState`
- provide `_scrollToBottom` helper and dispose controllers
- attach the controller to the message list
- automatically scroll down after sending a message and when new messages arrive

## Testing
- `flutter analyze` *(fails: current Flutter SDK version is 0.0.0-unknown)*
- `flutter test` *(fails: current Flutter SDK version is 0.0.0-unknown)*

------
https://chatgpt.com/codex/tasks/task_e_6877ea5fdcb8832f94eea33076858b6e