### PR TITLE
Cache invoice data in detail page

### DIFF
--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -17,6 +17,7 @@ class InvoiceDetailPage extends StatefulWidget {
 }
 
 class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
+  late final Future<Map<String, dynamic>?> _invoiceFuture;
   Future<Map<String, dynamic>?> _loadInvoice() async {
     final doc = await FirebaseFirestore.instance
         .collection('invoices')
@@ -40,9 +41,15 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
   }
 
   @override
+  void initState() {
+    super.initState();
+    _invoiceFuture = _loadInvoice();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return FutureBuilder<Map<String, dynamic>?>(
-      future: _loadInvoice(),
+      future: _invoiceFuture,
       builder: (context, snapshot) {
         if (!snapshot.hasData) {
           if (snapshot.connectionState == ConnectionState.waiting) {


### PR DESCRIPTION
## Summary
- avoid multiple Firestore queries in invoice detail page

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877f5e85aa8832f8eaf26616642089c