### PR TITLE
Store mechanic updates in users collection

### DIFF
--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -115,10 +115,14 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
       'location': currentPosition != null
           ? {'lat': currentPosition!.latitude, 'lng': currentPosition!.longitude}
           : FieldValue.delete(),
+      'role': 'mechanic',
+      'timestamp': DateTime.now(),
     };
 
-    await FirebaseFirestore.instance.collection('users').doc(widget.userId).update(data);
-    await FirebaseFirestore.instance.collection('mechanics').doc(widget.userId).update(data);
+    await FirebaseFirestore.instance
+        .collection('users')
+        .doc(widget.userId)
+        .update(data);
 
     setState(() {
       isActive = !isActive;
@@ -383,14 +387,16 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                   },
                   onChangeEnd: (val) {
                     if (isActive) {
-                      FirebaseFirestore.instance.collection('users').doc(widget.userId).update({
+                      FirebaseFirestore.instance
+                          .collection('users')
+                          .doc(widget.userId)
+                          .update({
                         'radiusMiles': val,
-                      });
-                      FirebaseFirestore.instance.collection('mechanics').doc(widget.userId).update({
-                        'radiusMiles': val,
+                        'role': 'mechanic',
+                        'timestamp': DateTime.now(),
                       });
                     }
-                  },
+                 },
                 ),
                 Text('Service Radius: ${radiusMiles.toInt()} miles'),
               ],
@@ -425,18 +431,15 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
       });
 
       if (isActive && currentPosition != null) {
-        await FirebaseFirestore.instance.collection('mechanics').doc(widget.userId).update({
+        await FirebaseFirestore.instance
+            .collection('users')
+            .doc(widget.userId)
+            .update({
           'location': {
             'lat': currentPosition!.latitude,
             'lng': currentPosition!.longitude,
           },
-          'timestamp': DateTime.now(),
-        });
-        await FirebaseFirestore.instance.collection('users').doc(widget.userId).update({
-          'location': {
-            'lat': currentPosition!.latitude,
-            'lng': currentPosition!.longitude,
-          },
+          'role': 'mechanic',
           'timestamp': DateTime.now(),
         });
       }


### PR DESCRIPTION
## Summary
- write mechanic status, radius, and location updates only to `users` collection
- include role and timestamp in mechanic updates

## Testing
- `flutter` and `dart` were not available so tests could not be executed

------
https://chatgpt.com/codex/tasks/task_e_6877f360e6ac832fa7ef4cfd89428f0d