### PR TITLE
Add completion confirmation dialog

### DIFF
--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -83,11 +83,43 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
               alignment: Alignment.centerRight,
               child: ElevatedButton(
                 onPressed: () async {
-                  await FirebaseFirestore.instance
-                      .collection('invoices')
-                      .doc(widget.invoiceId)
-                      .update({'status': 'completed'});
-                  if (mounted) Navigator.pop(context);
+                  final confirmed = await showDialog<bool>(
+                    context: context,
+                    builder: (context) {
+                      return AlertDialog(
+                        title: const Text('Mark as Completed'),
+                        content: const Text(
+                          'Are you sure you want to mark this job as completed?',
+                        ),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(false),
+                            child: const Text('Cancel'),
+                          ),
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(true),
+                            child: const Text('Confirm'),
+                          ),
+                        ],
+                      );
+                    },
+                  );
+
+                  if (confirmed == true) {
+                    await FirebaseFirestore.instance
+                        .collection('invoices')
+                        .doc(widget.invoiceId)
+                        .update({'status': 'completed'});
+
+                    if (mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Job marked as completed.'),
+                        ),
+                      );
+                      Navigator.pop(context);
+                    }
+                  }
                 },
                 child: const Text('Mark as Completed'),
               ),


### PR DESCRIPTION
## Summary
- ask for confirmation before marking invoice as completed
- update Firestore status on confirmation
- show snackbar then return to invoices list

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877f3b73298832f8b721f060ba09635