### PR TITLE
Implement 'Any Tech' mass request flow

### DIFF
--- a/lib/pages/create_invoice_page.dart
+++ b/lib/pages/create_invoice_page.dart
@@ -27,6 +27,7 @@ class _CreateInvoicePageState extends State<CreateInvoicePage> {
   final TextEditingController descriptionController = TextEditingController();
 
   bool isSubmitting = false;
+  bool get isAnyTech => widget.mechanicId == 'any';
 
   bool get isFormValid =>
       carYearController.text.isNotEmpty &&
@@ -92,7 +93,7 @@ class _CreateInvoicePageState extends State<CreateInvoicePage> {
         'mechanicId': widget.mechanicId,
         'customerId': widget.customerId,
         'mechanicUsername': widget.mechanicUsername,
-        'distance': widget.distance,
+        if (!isAnyTech) 'distance': widget.distance,
         'location': {
           'lat': position.latitude,
           'lng': position.longitude,
@@ -153,7 +154,8 @@ class _CreateInvoicePageState extends State<CreateInvoicePage> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text('Mechanic: ${widget.mechanicUsername}'),
-            Text('Distance: ${widget.distance.toStringAsFixed(1)} mi'),
+            if (!isAnyTech)
+              Text('Distance: ${widget.distance.toStringAsFixed(1)} mi'),
             const SizedBox(height: 16),
             TextField(
               controller: carYearController,

--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -275,6 +275,79 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
     );
   }
 
+  void _handleAnyTech() {
+    final activeMechanics = <Map<String, dynamic>>[];
+    mechanicsInRange.forEach((id, data) {
+      if (data['withinActive'] == true) {
+        activeMechanics.add({
+          'id': id,
+          'username': data['username'],
+          'distance': data['distance'],
+        });
+      }
+    });
+
+    if (activeMechanics.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('No mechanics in range')),
+      );
+      return;
+    }
+
+    Future<void> continueFn() async {
+      Navigator.pop(context); // close dialog if open
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => CreateInvoicePage(
+            customerId: widget.userId,
+            mechanicId: 'any',
+            mechanicUsername: 'Any Tech',
+            distance: 0,
+          ),
+        ),
+      );
+    }
+
+    if (activeMechanics.length > 1) {
+      showDialog(
+        context: context,
+        builder: (context) {
+          return AlertDialog(
+            title: const Text('Nearby Mechanics'),
+            content: SizedBox(
+              width: double.maxFinite,
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: activeMechanics.length,
+                itemBuilder: (context, index) {
+                  final m = activeMechanics[index];
+                  final dist = (m['distance'] as double).toStringAsFixed(1);
+                  return ListTile(
+                    title: Text(m['username'] ?? 'Unnamed'),
+                    subtitle: Text('$dist mi away'),
+                  );
+                },
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Cancel'),
+              ),
+              ElevatedButton(
+                onPressed: continueFn,
+                child: const Text('Request Service'),
+              ),
+            ],
+          );
+        },
+      );
+    } else {
+      continueFn();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -358,9 +431,7 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
                             ElevatedButton(
-                              onPressed: () {
-                                // TODO: implement any tech logic
-                              },
+                              onPressed: _handleAnyTech,
                               child: const Text("Any Tech"),
                             ),
                             const SizedBox(width: 10),

--- a/lib/pages/invoices_page.dart
+++ b/lib/pages/invoices_page.dart
@@ -62,9 +62,12 @@ class _InvoicesPageState extends State<InvoicesPage> {
         }
 
         Query<Map<String, dynamic>> query = FirebaseFirestore.instance
-            .collection('invoices')
-            .where(role == 'customer' ? 'customerId' : 'mechanicId',
-                isEqualTo: widget.userId);
+            .collection('invoices');
+        if (role == 'customer') {
+          query = query.where('customerId', isEqualTo: widget.userId);
+        } else {
+          query = query.where('mechanicId', whereIn: [widget.userId, 'any']);
+        }
         if (_selectedFilter == 'active' || _selectedFilter == 'completed') {
           query = query.where('status', isEqualTo: _selectedFilter);
         }

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -141,7 +141,7 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
     invoiceSubscription?.cancel();
     invoiceSubscription = FirebaseFirestore.instance
         .collection('invoices')
-        .where('mechanicId', isEqualTo: widget.userId)
+        .where('mechanicId', whereIn: [widget.userId, 'any'])
         .where('status', isEqualTo: 'active')
         .snapshots()
         .listen((snapshot) {


### PR DESCRIPTION
## Summary
- add mass-request logic to `Any Tech` button for customers
- support 'any' mechanicId when creating invoices
- update mechanics' invoice listeners for 'any tech' requests
- show invoices where mechanicId matches user or 'any'
- hide distance on invoice form when not applicable

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877fae68568832f9c0d4d40778663de