### PR TITLE
Implement auth-aware home page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,23 +1,29 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'firebase_options.dart';
 import 'pages/login_page.dart';
+import 'pages/dashboard_page.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
-  runApp(const MyApp());
+  final user = FirebaseAuth.instance.currentUser;
+  runApp(MyApp(initialUserId: user?.uid));
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  final String? initialUserId;
+  const MyApp({super.key, this.initialUserId});
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'SkipTow',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange)),
-      home: const LoginPage(),
+      home: initialUserId != null
+          ? DashboardPage(userId: initialUserId!)
+          : const LoginPage(),
     );
   }
 }


### PR DESCRIPTION
## Summary
- redirect users to dashboard if already signed in
- include FirebaseAuth in `main.dart` for session persistence

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877fb853280832f824a01c58923621f