### PR TITLE
Add basic help and support page

### DIFF
--- a/lib/pages/help_page.dart
+++ b/lib/pages/help_page.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Simple help and support page with usage instructions.
+class HelpPage extends StatelessWidget {
+  const HelpPage({super.key});
+
+  Future<void> _contactSupport() async {
+    final uri = Uri.parse('mailto:support@skiptow.com');
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    }
+  }
+
+  Widget _sectionTitle(String title) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 16, bottom: 8),
+      child: Text(
+        title,
+        style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Help & Support')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _sectionTitle('How to use the app'),
+            const Text(
+              'Customers can browse nearby mechanics on the map and send service '
+              'requests directly from their profile. Mechanics can toggle their '
+              'availability and manage jobs from the dashboard.',
+            ),
+            _sectionTitle('How to submit requests'),
+            const Text(
+              'From a mechanic profile, tap \"Request Service\" and fill out the '
+              'vehicle details and problem description. You will be notified once '
+              'a mechanic accepts the job.',
+            ),
+            _sectionTitle('How to receive jobs'),
+            const Text(
+              'Mechanics get notified of new requests in real time. View open '
+              'invoices to accept or complete a job.',
+            ),
+            _sectionTitle('How to contact support'),
+            const Text(
+              'If you have any issues with the app or your account, you can reach '
+              'our support team at any time.',
+            ),
+            const SizedBox(height: 20),
+            Center(
+              child: ElevatedButton(
+                onPressed: _contactSupport,
+                child: const Text('Contact Support'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   geolocator: ^11.0.0
   google_maps_flutter: ^2.6.0
   permission_handler: ^11.0.1
+  url_launcher: ^6.2.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- add `url_launcher` dependency
- create new HelpPage with simple instructions and "Contact Support" button

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687831c3e6a4832f94e76411bea68061