### PR TITLE
Add Help button to dashboard

### DIFF
--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -6,6 +6,7 @@ import 'customer_dashboard.dart';
 import 'login_page.dart';
 import 'settings_page.dart';
 import 'admin_dashboard.dart';
+import 'help_page.dart';
 
 class DashboardPage extends StatelessWidget {
   final String userId;
@@ -89,6 +90,20 @@ class DashboardPage extends StatelessWidget {
                 },
                 tooltip: 'Settings',
                 child: const Icon(Icons.settings),
+              ),
+              const SizedBox(height: 12),
+              FloatingActionButton(
+                heroTag: 'help_button',
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const HelpPage(),
+                    ),
+                  );
+                },
+                tooltip: 'Help / Support',
+                child: const Icon(Icons.help_outline),
               ),
               const SizedBox(height: 12),
               FloatingActionButton(


### PR DESCRIPTION
## Summary
- add `help_page.dart` import
- add floating action button for "Help / Support" that navigates to the Help page

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687832b93048832fb43bf3a2fe40021c