### PR TITLE
Add customer service request history button

### DIFF
--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -7,6 +7,7 @@ import 'login_page.dart';
 import 'settings_page.dart';
 import 'admin_dashboard.dart';
 import 'help_page.dart';
+import 'service_request_history_page.dart';
 
 class DashboardPage extends StatelessWidget {
   final String userId;
@@ -105,6 +106,22 @@ class DashboardPage extends StatelessWidget {
                 tooltip: 'Help / Support',
                 child: const Icon(Icons.help_outline),
               ),
+              if (role == 'customer') ...[
+                const SizedBox(height: 12),
+                FloatingActionButton(
+                  heroTag: 'history_button',
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => ServiceRequestHistoryPage(userId: userId),
+                      ),
+                    );
+                  },
+                  tooltip: 'My Service Requests',
+                  child: const Icon(Icons.history),
+                ),
+              ],
               const SizedBox(height: 12),
               FloatingActionButton(
                 heroTag: 'logout_button',


### PR DESCRIPTION
## Summary
- show Service Request History button in DashboardPage for customers
- navigate to ServiceRequestHistoryPage when pressed

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687839f9f76c832f9564a62a95509ede