### PR TITLE
Add admin dashboard button

### DIFF
--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -64,7 +64,7 @@ class DashboardPage extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               if (userId == _adminUserId) ...[
-                FloatingActionButton(
+                FloatingActionButton.extended(
                   heroTag: 'admin_button',
                   onPressed: () {
                     Navigator.push(
@@ -74,8 +74,8 @@ class DashboardPage extends StatelessWidget {
                       ),
                     );
                   },
-                  tooltip: 'Admin Dashboard',
-                  child: const Icon(Icons.admin_panel_settings),
+                  label: const Text('Admin Dashboard'),
+                  icon: const Icon(Icons.admin_panel_settings),
                 ),
                 const SizedBox(height: 12),
               ],


### PR DESCRIPTION
## Summary
- show a labeled "Admin Dashboard" button on DashboardPage when current user is admin

## Testing
- `flutter test` *(fails: Dart SDK version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_68783b649f5c832f861fb1f3359300ac