### PR TITLE
Show phone and email on invoice details

### DIFF
--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -30,7 +30,12 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
         .collection('users')
         .doc(data['customerId'])
         .get();
-    data['customerUsername'] = customerDoc.data()?['username'] ?? 'Unknown';
+    final customerData = customerDoc.data();
+    data['customerUsername'] = customerData?['username'] ?? 'Unknown';
+    // Optional contact info
+    data['customerPhone'] =
+        customerData?['phone'] ?? customerData?['phoneNumber'];
+    data['customerEmail'] = customerData?['email'];
     return data;
   }
 
@@ -76,6 +81,10 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
           if (carText.isNotEmpty) Text('Car: $carText'),
           if ((data['description'] ?? '').toString().isNotEmpty)
             Text('Problem: ${data['description']}'),
+          if ((data['customerPhone'] ?? '').toString().isNotEmpty)
+            Text('Phone: ${data['customerPhone']}'),
+          if ((data['customerEmail'] ?? '').toString().isNotEmpty)
+            Text('Email: ${data['customerEmail']}'),
           if (location != null)
             Text('Location: ${location['lat']}, ${location['lng']}'),
           if (data['distance'] != null)


### PR DESCRIPTION
## Summary
- display customer's phone and email on invoice detail page
- fetch contact info from `users/{customerId}` when loading invoice

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68783d90b834832f8ea543109bd5f6cf