### PR TITLE
Add legal page navigation on auth screens

### DIFF
--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -3,6 +3,8 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:skiptow/pages/dashboard_page.dart';
 import 'package:skiptow/pages/signup_page.dart';
+import 'package:skiptow/pages/terms_of_service_page.dart';
+import 'package:skiptow/pages/privacy_policy_page.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -57,6 +59,35 @@ class _LoginPageState extends State<LoginPage> {
             }, child: const Text('Create new account')),
             const SizedBox(height: 20),
             Text(_status, style: const TextStyle(color: Colors.red)),
+            const SizedBox(height: 20),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                TextButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const TermsOfServicePage(),
+                      ),
+                    );
+                  },
+                  child: const Text('Terms of Service'),
+                ),
+                const SizedBox(width: 16),
+                TextButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const PrivacyPolicyPage(),
+                      ),
+                    );
+                  },
+                  child: const Text('Privacy Policy'),
+                ),
+              ],
+            ),
           ],
         ),
       ),

--- a/lib/pages/privacy_policy_page.dart
+++ b/lib/pages/privacy_policy_page.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class PrivacyPolicyPage extends StatelessWidget {
+  const PrivacyPolicyPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Privacy Policy')),
+      body: const SingleChildScrollView(
+        padding: EdgeInsets.all(16),
+        child: Text(
+          'This is where the privacy policy will be displayed. '
+          'Please review it for information on how your data is used.',
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/signup_page.dart
+++ b/lib/pages/signup_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:skiptow/pages/privacy_policy_page.dart';
+import 'package:skiptow/pages/terms_of_service_page.dart';
 
 class SignupPage extends StatefulWidget {
   const SignupPage({super.key});
@@ -104,6 +106,35 @@ class _SignupPageState extends State<SignupPage> {
             ),
             const SizedBox(height: 12),
             Text(_status, style: const TextStyle(color: Colors.red)),
+            const SizedBox(height: 20),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                TextButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const TermsOfServicePage(),
+                      ),
+                    );
+                  },
+                  child: const Text('Terms of Service'),
+                ),
+                const SizedBox(width: 16),
+                TextButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const PrivacyPolicyPage(),
+                      ),
+                    );
+                  },
+                  child: const Text('Privacy Policy'),
+                ),
+              ],
+            ),
           ],
         ),
       ),

--- a/lib/pages/terms_of_service_page.dart
+++ b/lib/pages/terms_of_service_page.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class TermsOfServicePage extends StatelessWidget {
+  const TermsOfServicePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Terms of Service')),
+      body: const SingleChildScrollView(
+        padding: EdgeInsets.all(16),
+        child: Text(
+          'This is where the terms of service will be displayed. '
+          'Please read them carefully.',
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create privacy policy and terms of service pages
- link the new legal pages from login and signup screens

## Testing
- `dart format -o none --set-exit-if-changed lib/pages/login_page.dart lib/pages/signup_page.dart lib/pages/privacy_policy_page.dart lib/pages/terms_of_service_page.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68784301f300832fac0a53da2ac42635