### PR TITLE
Add loading indicator for invoice submission

### DIFF
--- a/lib/pages/create_invoice_page.dart
+++ b/lib/pages/create_invoice_page.dart
@@ -88,6 +88,12 @@ class _CreateInvoicePageState extends State<CreateInvoicePage> {
       isSubmitting = true;
     });
 
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const Center(child: CircularProgressIndicator()),
+    );
+
     try {
       final position = await Geolocator.getCurrentPosition();
       final userEmail = FirebaseAuth.instance.currentUser?.email ?? '';
@@ -120,14 +126,15 @@ class _CreateInvoicePageState extends State<CreateInvoicePage> {
       phoneController.clear();
 
       if (mounted) {
+        Navigator.of(context).pop(); // hide loading
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Invoice submitted')),
         );
+        Navigator.pop(context);
       }
-
-      if (mounted) Navigator.pop(context);
     } catch (e) {
       if (mounted) {
+        Navigator.of(context).pop(); // hide loading
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
               content: Text('An error occurred. Please try again.')),


### PR DESCRIPTION
## Summary
- show `CircularProgressIndicator` when submitting invoice
- hide indicator and show snackbar once submission completes
- prevent double submissions while loading

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68784e8b1750832fadf8e6a6161e33a4