### PR TITLE
Hide mechanic info in customer view

### DIFF
--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -36,6 +36,18 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
     data['customerPhone'] =
         customerData?['phone'] ?? customerData?['phoneNumber'];
     data['customerEmail'] = customerData?['email'];
+
+    // Fetch mechanic contact info for non-customer views
+    if (widget.role != 'customer') {
+      final mechDoc = await FirebaseFirestore.instance
+          .collection('users')
+          .doc(data['mechanicId'])
+          .get();
+      final mechData = mechDoc.data();
+      data['mechanicPhone'] =
+          mechData?['phone'] ?? mechData?['phoneNumber'];
+      data['mechanicEmail'] = mechData?['email'];
+    }
     return data;
   }
 
@@ -81,10 +93,20 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
           if (carText.isNotEmpty) Text('Car: $carText'),
           if ((data['description'] ?? '').toString().isNotEmpty)
             Text('Problem: ${data['description']}'),
-          if ((data['customerPhone'] ?? '').toString().isNotEmpty)
+          // Show customer contact info only to mechanics
+          if (widget.role == 'mechanic' &&
+              (data['customerPhone'] ?? '').toString().isNotEmpty)
             Text('Phone: ${data['customerPhone']}'),
-          if ((data['customerEmail'] ?? '').toString().isNotEmpty)
+          if (widget.role == 'mechanic' &&
+              (data['customerEmail'] ?? '').toString().isNotEmpty)
             Text('Email: ${data['customerEmail']}'),
+          // Show mechanic contact info to non-customers (e.g. mechanic or admin)
+          if (widget.role != 'customer' &&
+              (data['mechanicPhone'] ?? '').toString().isNotEmpty)
+            Text('Mechanic Phone: ${data['mechanicPhone']}'),
+          if (widget.role != 'customer' &&
+              (data['mechanicEmail'] ?? '').toString().isNotEmpty)
+            Text('Mechanic Email: ${data['mechanicEmail']}'),
           if (location != null)
             Text('Location: ${location['lat']}, ${location['lng']}'),
           if (data['distance'] != null)

--- a/lib/pages/invoices_page.dart
+++ b/lib/pages/invoices_page.dart
@@ -209,6 +209,13 @@ class _InvoiceTile extends StatelessWidget {
       ),
       if (carText.isNotEmpty) Text(carText),
       if (description.toString().isNotEmpty) Text(description),
+      // Customer contact details visible only to mechanics
+      if (role == 'mechanic' &&
+          (data['customerPhone'] ?? '').toString().isNotEmpty)
+        Text('Phone: ${data['customerPhone']}'),
+      if (role == 'mechanic' &&
+          (data['customerEmail'] ?? '').toString().isNotEmpty)
+        Text('Email: ${data['customerEmail']}'),
       if (distance != null) Text('Distance: ${distance.toStringAsFixed(1)} mi'),
       Text('Submitted on ${_formatDate(ts)}'),
     ];


### PR DESCRIPTION
## Summary
- only show mechanic contact details to non-customer roles in invoice details
- surface customer phone/email on invoice tiles only for mechanics

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687851a318f0832f9db546628a0cd349