### PR TITLE
Fix invoice double submit

### DIFF
--- a/lib/pages/create_invoice_page.dart
+++ b/lib/pages/create_invoice_page.dart
@@ -74,19 +74,28 @@ class _CreateInvoicePageState extends State<CreateInvoicePage> {
   }
 
   Future<void> _submitInvoice() async {
+    if (isSubmitting) return;
+    setState(() {
+      isSubmitting = true;
+    });
+
     if (!isFormValid) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Please fill all fields')),
       );
+      setState(() {
+        isSubmitting = false;
+      });
       return;
     }
 
     final hasPermission = await _handleLocationPermission();
-    if (!hasPermission) return;
-
-    setState(() {
-      isSubmitting = true;
-    });
+    if (!hasPermission) {
+      setState(() {
+        isSubmitting = false;
+      });
+      return;
+    }
 
     showDialog(
       context: context,


### PR DESCRIPTION
## Summary
- disable the `Submit Invoice` button immediately when pressed
- keep it disabled until the Firestore write finishes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687853aafeb0832fa3ba0541ce799100