### PR TITLE
Highlight cancelled invoices in lists

### DIFF
--- a/lib/pages/invoices_page.dart
+++ b/lib/pages/invoices_page.dart
@@ -299,6 +299,12 @@ class _InvoiceTile extends StatelessWidget {
       },
       child: Card(
         margin: const EdgeInsets.all(8),
+        shape: status == 'cancelled'
+            ? RoundedRectangleBorder(
+                side: const BorderSide(color: Colors.red, width: 2),
+                borderRadius: BorderRadius.circular(4),
+              )
+            : null,
         child: Padding(
           padding: const EdgeInsets.all(12),
           child: Column(

--- a/lib/pages/service_request_history_page.dart
+++ b/lib/pages/service_request_history_page.dart
@@ -60,6 +60,12 @@ class ServiceRequestHistoryPage extends StatelessWidget {
 
               return Card(
                 margin: const EdgeInsets.all(8),
+                shape: status == 'cancelled'
+                    ? RoundedRectangleBorder(
+                        side: const BorderSide(color: Colors.red, width: 2),
+                        borderRadius: BorderRadius.circular(4),
+                      )
+                    : null,
                 child: Padding(
                   padding: const EdgeInsets.all(12),
                   child: Column(


### PR DESCRIPTION
## Summary
- highlight cancelled invoices with a red border in invoice lists

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687855f326ec832faf6aff287cf4b3dd