### PR TITLE
Add service status display for mechanics

### DIFF
--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -447,6 +447,20 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
             )
           : Column(
               children: [
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(8),
+                  color: isActive ? Colors.green : Colors.red,
+                  child: Text(
+                    'Service Status: ${isActive ? 'Active' : 'Inactive'}',
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
                 SizedBox(
                   height: 300,
                   child: Stack(


### PR DESCRIPTION
## Summary
- show a colored service status banner at the top of Mechanic Dashboard

## Testing
- `dart analyze` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_687856fabb58832fa0fa1a760823c3ac