### PR TITLE
Block duplicate service requests

### DIFF
--- a/lib/pages/create_invoice_page.dart
+++ b/lib/pages/create_invoice_page.dart
@@ -89,6 +89,26 @@ class _CreateInvoicePageState extends State<CreateInvoicePage> {
       return;
     }
 
+    // Check for an existing active invoice for this customer before proceeding
+    final activeSnapshot = await FirebaseFirestore.instance
+        .collection('invoices')
+        .where('customerId', isEqualTo: widget.customerId)
+        .where('status', isEqualTo: 'active')
+        .limit(1)
+        .get();
+    if (activeSnapshot.docs.isNotEmpty) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+              content: Text('You already have an active service request.')),
+        );
+      }
+      setState(() {
+        isSubmitting = false;
+      });
+      return;
+    }
+
     final hasPermission = await _handleLocationPermission();
     if (!hasPermission) {
       setState(() {


### PR DESCRIPTION
## Summary
- prevent customers from submitting a new invoice if they already have an active one

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68785da91bb8832fb62bd3d93eb3bf21