### PR TITLE
Prevent active status without location

### DIFF
--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -203,7 +203,20 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
     if (!hasPermission) return;
 
     if (!isActive) {
-      currentPosition = await Geolocator.getCurrentPosition();
+      try {
+        currentPosition = await Geolocator.getCurrentPosition();
+      } catch (_) {
+        currentPosition = null;
+      }
+      if (currentPosition == null) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+                content: Text('Cannot go active. Location unavailable.')),
+          );
+        }
+        return;
+      }
     }
 
     final data = {


### PR DESCRIPTION
## Summary
- prevent a mechanic from going Active when their location is unavailable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68785eea5fb0832fac8d73bc5c7a1de2