### PR TITLE
Display dynamic app version in login and settings pages

### DIFF
--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -5,6 +5,7 @@ import 'package:skiptow/pages/dashboard_page.dart';
 import 'package:skiptow/pages/signup_page.dart';
 import 'package:skiptow/pages/terms_of_service_page.dart';
 import 'package:skiptow/pages/privacy_policy_page.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -18,6 +19,26 @@ class _LoginPageState extends State<LoginPage> {
   String _status = '';
   final FirebaseAuth _auth = FirebaseAuth.instance;
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  String _appVersion = '1.0.0';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadAppVersion();
+  }
+
+  Future<void> _loadAppVersion() async {
+    try {
+      final info = await PackageInfo.fromPlatform();
+      if (mounted) {
+        setState(() {
+          _appVersion = info.version;
+        });
+      }
+    } catch (_) {
+      // Keep default version on failure
+    }
+  }
 
   Future<void> _login() async {
     setState(() { _status = 'Signing in...'; });
@@ -91,7 +112,7 @@ class _LoginPageState extends State<LoginPage> {
           const Spacer(),
           Center(
             child: Text(
-              'App Version 1.0.0',
+              'App Version: $_appVersion',
               textAlign: TextAlign.center,
               style: Theme.of(context)
                   .textTheme

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 import 'login_page.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
@@ -14,12 +15,13 @@ class SettingsPage extends StatefulWidget {
 class _SettingsPageState extends State<SettingsPage> {
   String? _role;
   String? _username;
-  final String _appVersion = '1.0.0';
+  String _appVersion = '1.0.0';
 
   @override
   void initState() {
     super.initState();
     _loadUserInfo();
+    _loadAppVersion();
   }
 
   Future<void> _loadUserInfo() async {
@@ -34,6 +36,19 @@ class _SettingsPageState extends State<SettingsPage> {
           _username = data?['username'];
         });
       }
+    }
+  }
+
+  Future<void> _loadAppVersion() async {
+    try {
+      final info = await PackageInfo.fromPlatform();
+      if (mounted) {
+        setState(() {
+          _appVersion = info.version;
+        });
+      }
+    } catch (_) {
+      // Keep default version on failure
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   permission_handler: ^11.0.1
   url_launcher: ^6.2.1
   intl: ^0.20.2
+  package_info_plus: ^8.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- fetch application version using `package_info_plus`
- show the fetched version on Login and Settings pages
- add `package_info_plus` to pubspec

## Testing
- `dart` command not available; skipped formatting

------
https://chatgpt.com/codex/tasks/task_e_6878f0fb545c832fb5ac32a5d2fe2535