### PR TITLE
Block mechanic activation without location

### DIFF
--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -263,6 +263,15 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
 
   Future<void> _onTogglePressed() async {
     if (!isActive) {
+      if (!_locationPermissionGranted || currentPosition == null) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+                content: Text('Enable location access to go active.')),
+          );
+        }
+        return;
+      }
       final confirm = await showDialog<bool>(
         context: context,
         builder: (context) {


### PR DESCRIPTION
## Summary
- require location permission and position before activation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687901ec28a8832f9fa2bf6b08347a90