### PR TITLE
Allow multiple active mechanic requests

### DIFF
--- a/lib/pages/invoices_page.dart
+++ b/lib/pages/invoices_page.dart
@@ -76,12 +76,13 @@ class _InvoicesPageState extends State<InvoicesPage> {
           );
         }
 
-        Query<Map<String, dynamic>> query = FirebaseFirestore.instance
-            .collection('invoices');
+        Query<Map<String, dynamic>> query =
+            FirebaseFirestore.instance.collection('invoices');
         if (role == 'customer') {
           query = query.where('customerId', isEqualTo: widget.userId);
         } else {
-          query = query.where('mechanicId', whereIn: [widget.userId, 'any']);
+          // Mechanics only view invoices assigned to them
+          query = query.where('mechanicId', isEqualTo: widget.userId);
         }
         if (_selectedFilter == 'active' ||
             _selectedFilter == 'completed' ||

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -305,7 +305,8 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
     invoiceSubscription?.cancel();
     invoiceSubscription = FirebaseFirestore.instance
         .collection('invoices')
-        .where('mechanicId', whereIn: [widget.userId, 'any'])
+        // Monitor only invoices assigned to this mechanic
+        .where('mechanicId', isEqualTo: widget.userId)
         .where('status', isEqualTo: 'active')
         .snapshots()
         .listen((snapshot) {


### PR DESCRIPTION
## Summary
- limit mechanic invoice subscription to invoices assigned to them
- filter mechanic invoices list by mechanicId only

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879038d612c832fa71f0ade971dc9fd