### PR TITLE
Mark messages as read when opening thread

### DIFF
--- a/lib/pages/messages_page.dart
+++ b/lib/pages/messages_page.dart
@@ -48,6 +48,23 @@ class _MessagesPageState extends State<MessagesPage> {
     setState(() {
       _conversationId = convId;
     });
+
+    await _markMessagesAsRead();
+  }
+
+  Future<void> _markMessagesAsRead() async {
+    if (_conversationId == null) return;
+    final query = await FirebaseFirestore.instance
+        .collection('messages')
+        .doc(_conversationId)
+        .collection('threads')
+        .where('recipientId', isEqualTo: widget.currentUserId)
+        .where('isRead', isEqualTo: false)
+        .get();
+
+    for (final doc in query.docs) {
+      await doc.reference.update({'isRead': true});
+    }
   }
 
   Future<void> _sendMessage() async {


### PR DESCRIPTION
## Summary
- update message threads so that any unread messages addressed to the current user are marked as read when the conversation opens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687907b8d36c832fb3c09ec15a553233