### PR TITLE
Add active job count to mechanic dashboard

### DIFF
--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -563,6 +563,26 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
             )
           : Column(
               children: [
+                StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+                  stream: FirebaseFirestore.instance
+                      .collection('invoices')
+                      .where('mechanicId', isEqualTo: widget.userId)
+                      .where('status', isEqualTo: 'active')
+                      .snapshots(),
+                  builder: (context, snapshot) {
+                    final activeCount = snapshot.data?.size ?? 0;
+                    return Padding(
+                      padding: const EdgeInsets.all(8),
+                      child: Text(
+                        'Active Jobs: $activeCount',
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    );
+                  },
+                ),
                 Container(
                   width: double.infinity,
                   padding: const EdgeInsets.all(8),


### PR DESCRIPTION
## Summary
- show active job count at top of mechanic dashboard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68790e2a27b0832fa5ff07b523d78fab