### PR TITLE
Add back button to mechanic request queue

### DIFF
--- a/lib/pages/mechanic_request_queue_page.dart
+++ b/lib/pages/mechanic_request_queue_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'invoice_detail_page.dart';
+import 'mechanic_dashboard.dart';
 
 /// Page to view active service requests assigned to a mechanic.
 class MechanicRequestQueuePage extends StatefulWidget {
@@ -67,7 +68,26 @@ class _MechanicRequestQueuePageState extends State<MechanicRequestQueuePage> {
         final stream = query.snapshots();
 
         return Scaffold(
-          appBar: AppBar(title: const Text('Request Queue')),
+          appBar: AppBar(
+            title: const Text('Request Queue'),
+            automaticallyImplyLeading: false,
+            leading: IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: () {
+                setState(() {
+                  _selectedFilter = 'active';
+                });
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => MechanicDashboard(
+                      userId: widget.mechanicId,
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
           body: Column(
             children: [
               Padding(


### PR DESCRIPTION
## Summary
- add missing import for `mechanic_dashboard.dart`
- add custom back arrow to the request queue page which resets filters and returns to the dashboard

## Testing
- `No tests run`

------
https://chatgpt.com/codex/tasks/task_e_68793b1d6ca0832f99871bffd5e079ce