### PR TITLE
Add notes display in invoice detail

### DIFF
--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -150,6 +150,10 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
           if (carText.isNotEmpty) Text('Car: $carText'),
           if ((data['description'] ?? '').toString().isNotEmpty)
             Text('Problem: ${data['description']}'),
+          if ((data['notes'] ?? '').toString().isNotEmpty)
+            Text('Customer Notes:\n${data['notes']}')
+          else
+            const Text('No additional notes.'),
           if (widget.role == 'customer')
             Text(
               finalPrice != null


### PR DESCRIPTION
## Summary
- show customer notes on invoice details when available

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68793b327bb0832f97c0a05be1b08bf4