### PR TITLE
Add vehicle history navigation for customers

### DIFF
--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -8,6 +8,7 @@ import 'settings_page.dart';
 import 'admin_dashboard.dart';
 import 'help_page.dart';
 import 'service_request_history_page.dart';
+import 'vehicle_history_page.dart';
 
 class DashboardPage extends StatelessWidget {
   final String userId;
@@ -149,6 +150,20 @@ class DashboardPage extends StatelessWidget {
                   },
                   tooltip: 'My Service Requests',
                   child: const Icon(Icons.history),
+                ),
+                const SizedBox(height: 12),
+                FloatingActionButton(
+                  heroTag: 'vehicles_button',
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => VehicleHistoryPage(userId: userId),
+                      ),
+                    );
+                  },
+                  tooltip: 'My Vehicles',
+                  child: const Icon(Icons.directions_car),
                 ),
               ],
               const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- import VehicleHistoryPage in dashboard
- add FloatingActionButton to open VehicleHistoryPage for customers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68793d3bd02c832f93a1ea4605ccd8d4