### PR TITLE
Add customer name to mechanic invoice view

### DIFF
--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -32,6 +32,8 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
         .doc(data['customerId'])
         .get();
     final customerData = customerDoc.data();
+    data['customerName'] =
+        customerData?['displayName'] ?? customerData?['username'];
     data['customerUsername'] = customerData?['username'] ?? 'Unknown';
     // Optional contact info
     data['customerPhone'] =
@@ -112,9 +114,22 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
         final status = data['status'] ?? 'active';
         final finalPrice = data['finalPrice'];
 
-        final children = <Widget>[
+        final children = <Widget>[];
+        if (widget.role == 'mechanic') {
+          final name = data['customerName'] ?? data['customerUsername'];
+          children.add(
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Text(
+                'Customer: ${name ?? 'Unknown'}',
+                style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
+            ),
+          );
+        }
+        children.add(
           Text('Mechanic: ${data['mechanicUsername'] ?? 'Unknown'}'),
-        ];
+        );
 
         if (widget.role == 'customer') {
           if (data['distanceToMechanic'] != null) {
@@ -146,7 +161,8 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
         }
 
         children.addAll([
-          Text('Customer: ${data['customerUsername'] ?? 'Unknown'}'),
+          if (widget.role != 'mechanic')
+            Text('Customer: ${data['customerName'] ?? data['customerUsername'] ?? 'Unknown'}'),
           if (carText.isNotEmpty) Text('Car: $carText'),
           if ((data['description'] ?? '').toString().isNotEmpty)
             Text('Problem: ${data['description']}'),


### PR DESCRIPTION
## Summary
- fetch customer's `displayName` or fallback to `username`
- show customer name prominently at the top of invoice details for mechanics

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68793d46ea70832f9790246a31897128