### PR TITLE
Add server timestamp when creating invoice

### DIFF
--- a/lib/pages/create_invoice_page.dart
+++ b/lib/pages/create_invoice_page.dart
@@ -176,6 +176,7 @@ class _CreateInvoicePageState extends State<CreateInvoicePage> {
           'notes': notesController.text.trim(),
         'customerPhone': phoneController.text.trim(),
         'customerEmail': userEmail,
+        'createdAt': FieldValue.serverTimestamp(),
         'timestamp': DateTime.now(),
         'status': 'active',
       });


### PR DESCRIPTION
## Summary
- store Firestore `createdAt` field for new invoices

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879404296d4832fbc356760e016136c