### PR TITLE
Add cancel request option for mechanics

### DIFF
--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -283,6 +283,54 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
               ),
             ),
           );
+
+          children.add(
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: () async {
+                  final confirmed = await showDialog<bool>(
+                    context: context,
+                    builder: (context) {
+                      return AlertDialog(
+                        title: const Text('Cancel Request'),
+                        content: const Text(
+                            'Are you sure you want to cancel this service request?'),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(false),
+                            child: const Text('No'),
+                          ),
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(true),
+                            child: const Text('Yes'),
+                          ),
+                        ],
+                      );
+                    },
+                  );
+
+                  if (confirmed == true) {
+                    await FirebaseFirestore.instance
+                        .collection('invoices')
+                        .doc(widget.invoiceId)
+                        .update({
+                      'status': 'cancelled',
+                      'cancelledBy': 'mechanic',
+                    });
+
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Request cancelled.')),
+                      );
+                      Navigator.pop(context);
+                    }
+                  }
+                },
+                child: const Text('Cancel Request'),
+              ),
+            ),
+          );
         }
 
         return Scaffold(


### PR DESCRIPTION
## Summary
- show **Cancel Request** button on mechanic's invoice detail view when invoice is active
- allow mechanics to cancel an invoice after confirmation dialog
- update Firestore with `cancelled` status and record who cancelled

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6879482b2bd0832fbb1d1b26580bb838