### PR TITLE
Restrict admin dashboard access

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'login_page.dart';
+import 'dashboard_page.dart';
 
 /// Simple admin dashboard for monitoring the platform.
 class AdminDashboardPage extends StatefulWidget {
@@ -338,9 +339,20 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
         }
 
         if (snapshot.data != 'admin') {
-          return const Scaffold(
-            body: Center(child: Text('Access denied')),
-          );
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Access denied.')),
+              );
+              Navigator.pushAndRemoveUntil(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => DashboardPage(userId: widget.userId)),
+                (route) => false,
+              );
+            }
+          });
+          return const SizedBox.shrink();
         }
 
         return Scaffold(

--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -50,6 +50,22 @@ class DashboardPage extends StatelessWidget {
         }
 
         final role = snapshot.data;
+        if (role == 'admin') {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (context.mounted) {
+              Navigator.pushReplacement(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => AdminDashboardPage(userId: userId),
+                ),
+              );
+            }
+          });
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+
         if (!_snackbarShown && role != null) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (context.mounted) {


### PR DESCRIPTION
## Summary
- ensure admin dashboard redirects if user is not an admin
- redirect admins directly to their dashboard on login

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879496da558832fbfeb5f4df3f340b6