### PR TITLE
Fix unmatched bracket in invoice page

### DIFF
--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -206,7 +206,7 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
           Text('Status: $status'),
           if (finalPrice != null && widget.role != 'customer')
             Text('Final Price: \$${finalPrice.toString()}'),
-        ];
+        ]);
 
         if (widget.role == 'mechanic' && status == 'active') {
           children.add(


### PR DESCRIPTION
## Summary
- close the `children.addAll` call properly in `invoice_detail_page.dart`

## Testing
- `python3` script to check bracket balance

------
https://chatgpt.com/codex/tasks/task_e_68794e9cd4b4832fb6f96545f6d3cfaa