### PR TITLE
Auto fill invoice description after messaging

### DIFF
--- a/lib/pages/create_invoice_page.dart
+++ b/lib/pages/create_invoice_page.dart
@@ -9,6 +9,7 @@ class CreateInvoicePage extends StatefulWidget {
   final String mechanicId;
   final String mechanicUsername;
   final double distance;
+  final String? defaultDescription;
 
   const CreateInvoicePage({
     super.key,
@@ -16,6 +17,7 @@ class CreateInvoicePage extends StatefulWidget {
     required this.mechanicId,
     required this.mechanicUsername,
     required this.distance,
+    this.defaultDescription,
   });
 
   @override
@@ -37,6 +39,9 @@ class _CreateInvoicePageState extends State<CreateInvoicePage> {
   @override
   void initState() {
     super.initState();
+    if (widget.defaultDescription != null) {
+      descriptionController.text = widget.defaultDescription!;
+    }
     _checkActiveRequest();
   }
 

--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -328,13 +328,28 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
                   ),
                 );
               } else {
-                Navigator.push(
+                await Navigator.push(
                   context,
                   MaterialPageRoute(
                     builder: (_) => MessagesPage(
                       currentUserId: widget.userId,
                       otherUserId: doc.id,
-                      initialMessage: "I'm nearby your radius. Are you available for service?",
+                      initialMessage:
+                          "I'm nearby your radius. Are you available for service?",
+                    ),
+                  ),
+                );
+                if (!mounted) return;
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => CreateInvoicePage(
+                      customerId: widget.userId,
+                      mechanicId: doc.id,
+                      mechanicUsername: data['username'] ?? 'Unnamed',
+                      distance: distance ?? 0,
+                      defaultDescription:
+                          'My car is near your location. Please assist.',
                     ),
                   ),
                 );


### PR DESCRIPTION
## Summary
- navigate to invoice page after optional message to mechanic
- allow `CreateInvoicePage` to accept an optional default description
- populate problem description with "My car is near your location. Please assist." when arriving from marker

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687953d3562c832f9c909c563761c442