### PR TITLE
Implement task 19B UI behaviour

### DIFF
--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -30,6 +30,7 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
   bool _locationPermissionGranted = false;
   bool _locationBannerVisible = false;
   bool _hasAccountData = true;
+  bool _noMechanicsSnackbarShown = false;
 
   void _showLocationBanner() {
     if (_locationBannerVisible || !mounted) return;
@@ -391,6 +392,16 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
               ? "❗❓Mechanic nearby, but you're ${inRange.values.first['distance'].toStringAsFixed(1)} mi outside their range"
               : "❌ No active mechanics nearby";
     });
+
+    if (noMechanics && !_noMechanicsSnackbarShown && mounted) {
+      _noMechanicsSnackbarShown = true;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('No mechanics available nearby.')),
+      );
+    }
+    if (!noMechanics) {
+      _noMechanicsSnackbarShown = false;
+    }
   }
 
   void _onMapCreated(GoogleMapController controller) {
@@ -740,19 +751,34 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
                             ElevatedButton(
-                              onPressed: _handleAnyTech,
+                              onPressed: _hasAvailableMechanics
+                                  ? _handleAnyTech
+                                  : () {
+                                      ScaffoldMessenger.of(context).showSnackBar(
+                                        const SnackBar(
+                                            content: Text('No mechanics available nearby.')),
+                                      );
+                                    },
                               child: const Text("Any Tech"),
                             ),
                             const SizedBox(width: 10),
                             ElevatedButton(
-                              onPressed: () {
-                                setState(() {
-                                  chooseTechMode = true;
-                                });
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(content: Text("☝🏽 Find and tap a mechanic icon")),
-                                );
-                              },
+                              onPressed: _hasAvailableMechanics
+                                  ? () {
+                                      setState(() {
+                                        chooseTechMode = true;
+                                      });
+                                      ScaffoldMessenger.of(context).showSnackBar(
+                                        const SnackBar(
+                                            content: Text("☝🏽 Find and tap a mechanic icon")),
+                                      );
+                                    }
+                                  : () {
+                                      ScaffoldMessenger.of(context).showSnackBar(
+                                        const SnackBar(
+                                            content: Text('No mechanics available nearby.')),
+                                      );
+                                    },
                               child: const Text("Choose Tech"),
                             ),
                           ],


### PR DESCRIPTION
## Summary
- add snackbar flag for "no mechanics" message
- show snackbar when no mechanics are detected
- disable Any Tech/Choose Tech buttons when there are no active mechanics

## Testing
- `dart format lib/pages/customer_dashboard.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68795a6111bc832fbb0f635aea7b858a