### PR TITLE
Implement vehicle history persistence

### DIFF
--- a/lib/pages/vehicle_history_page.dart
+++ b/lib/pages/vehicle_history_page.dart
@@ -10,40 +10,39 @@ class VehicleHistoryPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Stream<QuerySnapshot<Map<String, dynamic>>> stream = FirebaseFirestore.instance
-        .collection('invoices')
-        .where('customerId', isEqualTo: userId)
-        .orderBy('timestamp', descending: true)
-        .snapshots();
+    final Stream<DocumentSnapshot<Map<String, dynamic>>> stream =
+        FirebaseFirestore.instance
+            .collection('users')
+            .doc(userId)
+            .snapshots();
 
     return Scaffold(
       appBar: AppBar(title: const Text('My Vehicles')),
-      body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+      body: StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
         stream: stream,
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator());
           }
 
-          final docs = snapshot.data?.docs ?? [];
-          final Set<String> uniqueVehicles = {};
-          for (var d in docs) {
-            final data = d.data();
-            final car = data['carInfo'] ?? {};
-            final year = (car['year'] ?? '').toString();
-            final make = (car['make'] ?? '').toString();
-            final model = (car['model'] ?? '').toString();
-            final vehicle = [year, make, model].where((e) => e.isNotEmpty).join(' ');
-            if (vehicle.isNotEmpty) {
-              uniqueVehicles.add(vehicle);
-            }
-          }
+          final List<dynamic> raw =
+              (snapshot.data?.data()?['vehicles'] as List<dynamic>?) ?? [];
+          final vehicles = raw
+              .whereType<Map<String, dynamic>>()
+              .map((car) {
+                final year = (car['year'] ?? '').toString();
+                final make = (car['make'] ?? '').toString();
+                final model = (car['model'] ?? '').toString();
+                return [year, make, model]
+                    .where((e) => e.isNotEmpty)
+                    .join(' ');
+              })
+              .where((v) => v.isNotEmpty)
+              .toList();
 
-          if (uniqueVehicles.isEmpty) {
+          if (vehicles.isEmpty) {
             return const Center(child: Text('No vehicles found'));
           }
-
-          final vehicles = uniqueVehicles.toList();
           return ListView.builder(
             itemCount: vehicles.length,
             itemBuilder: (context, index) {


### PR DESCRIPTION
## Summary
- save the vehicle information to the `users` document after submitting an invoice
- pull vehicle history from the `users/{id}.vehicles` array instead of invoices

## Testing
- `dart` unavailable; repo has no tests

------
https://chatgpt.com/codex/tasks/task_e_68795c6b6a9c832fbae36017a1d3168f