### PR TITLE
Add arrival confirmation flow

### DIFF
--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -579,6 +579,33 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
     );
   }
 
+  Widget _buildArrivalOverlay() {
+    final stream = FirebaseFirestore.instance
+        .collection('invoices')
+        .where('customerId', isEqualTo: widget.userId)
+        .where('status', isEqualTo: 'arrived')
+        .limit(1)
+        .snapshots();
+
+    return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+      stream: stream,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+          return const SizedBox.shrink();
+        }
+
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(0.9),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: const Text('🚗 Mechanic has arrived!'),
+        );
+      },
+    );
+  }
+
   Widget _buildMechanicCountOverlay() {
     final text = availableMechanicCount > 0
         ? 'Available Mechanics Nearby: ' + availableMechanicCount.toString()
@@ -791,6 +818,11 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
                   top: 10,
                   left: 10,
                   child: _buildActiveInvoiceOverlay(),
+                ),
+                Positioned(
+                  top: 90,
+                  left: 10,
+                  child: _buildArrivalOverlay(),
                 ),
                 Positioned(
                   bottom: 20,

--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -208,7 +208,31 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
             Text('Final Price: \$${finalPrice.toString()}'),
         ]);
 
-        if (widget.role == 'mechanic' && status == 'active') {
+        if (widget.role == 'mechanic' && status == 'accepted') {
+          children.add(
+            Align(
+              alignment: Alignment.centerRight,
+              child: ElevatedButton(
+                onPressed: () async {
+                  await FirebaseFirestore.instance
+                      .collection('invoices')
+                      .doc(widget.invoiceId)
+                      .update({'status': 'arrived'});
+
+                  if (mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Arrival confirmed.')),
+                    );
+                  }
+                },
+                child: const Text('Confirm Arrival'),
+              ),
+            ),
+          );
+        }
+
+        if (widget.role == 'mechanic' &&
+            (status == 'active' || status == 'accepted' || status == 'arrived')) {
           children.add(
             Align(
               alignment: Alignment.centerRight,


### PR DESCRIPTION
## Summary
- allow mechanics to confirm arrival from invoice detail page
- show mechanic arrival message for customers near the map

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68795f657cd4832f97536d4d5dd17cc5