### PR TITLE
Add start work status and overlay

### DIFF
--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -625,6 +625,33 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
     );
   }
 
+  Widget _buildInProgressOverlay() {
+    final stream = FirebaseFirestore.instance
+        .collection('invoices')
+        .where('customerId', isEqualTo: widget.userId)
+        .where('status', isEqualTo: 'in_progress')
+        .limit(1)
+        .snapshots();
+
+    return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+      stream: stream,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+          return const SizedBox.shrink();
+        }
+
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(0.9),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: const Text('🛠️ Mechanic is working on your vehicle.'),
+        );
+      },
+    );
+  }
+
   Widget _buildMechanicCountOverlay() {
     final text = availableMechanicCount > 0
         ? 'Available Mechanics Nearby: ' + availableMechanicCount.toString()
@@ -924,6 +951,11 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
                   top: 90,
                   left: 10,
                   child: _buildArrivalOverlay(),
+                ),
+                Positioned(
+                  top: 130,
+                  left: 10,
+                  child: _buildInProgressOverlay(),
                 ),
                 Positioned(
                   bottom: 20,

--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -231,8 +231,34 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
           );
         }
 
+        if (widget.role == 'mechanic' && status == 'arrived') {
+          children.add(
+            Align(
+              alignment: Alignment.centerRight,
+              child: ElevatedButton(
+                onPressed: () async {
+                  await FirebaseFirestore.instance
+                      .collection('invoices')
+                      .doc(widget.invoiceId)
+                      .update({'status': 'in_progress'});
+
+                  if (mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Work marked as started.')),
+                    );
+                  }
+                },
+                child: const Text('Start Work'),
+              ),
+            ),
+          );
+        }
+
         if (widget.role == 'mechanic' &&
-            (status == 'active' || status == 'accepted' || status == 'arrived')) {
+            (status == 'active' ||
+                status == 'accepted' ||
+                status == 'arrived' ||
+                status == 'in_progress')) {
           children.add(
             Align(
               alignment: Alignment.centerRight,


### PR DESCRIPTION
## Summary
- enable mechanics to mark work as started from invoice detail
- display progress overlay for customers when mechanic is working

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687962b9a688832f85082749f1f7b41b