### PR TITLE
Add option to close completed invoices

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -51,7 +51,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
     _invoiceSub = _invoiceStream.listen(_updateInvoiceCounts);
     _completedJobsSub = FirebaseFirestore.instance
         .collection('invoices')
-        .where('status', isEqualTo: 'completed')
+        .where('status', whereIn: ['completed', 'closed'])
         .snapshots()
         .listen((snapshot) {
       if (mounted) {
@@ -90,7 +90,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
 
     final completedSnap = await FirebaseFirestore.instance
         .collection('invoices')
-        .where('status', isEqualTo: 'completed')
+        .where('status', whereIn: ['completed', 'closed'])
         .get();
     _completedInvoices = completedSnap.size;
     _platformCompletedJobs = completedSnap.size;
@@ -112,7 +112,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
       final status = doc.data()['status'];
       if (status == 'active') {
         active++;
-      } else if (status == 'completed') {
+      } else if (status == 'completed' || status == 'closed') {
         completed++;
       } else if (status == 'cancelled') {
         cancelled++;
@@ -243,7 +243,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
           final status = d.data()['status'];
           if (status == 'active') {
             active.add(d);
-          } else if (status == 'completed') {
+          } else if (status == 'completed' || status == 'closed') {
             completed.add(d);
           } else if (status == 'cancelled') {
             cancelled.add(d);

--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -142,7 +142,7 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
     _completedInvoiceSub = FirebaseFirestore.instance
         .collection('invoices')
         .where('customerId', isEqualTo: widget.userId)
-        .where('status', isEqualTo: 'completed')
+        .where('status', whereIn: ['completed', 'closed'])
         .snapshots()
         .listen((snapshot) {
       if (snapshot.docs.isNotEmpty) {

--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -391,6 +391,54 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
           );
         }
 
+        if (widget.role == 'customer' && status == 'completed') {
+          children.add(
+            Align(
+              alignment: Alignment.centerRight,
+              child: ElevatedButton(
+                onPressed: () async {
+                  final confirmed = await showDialog<bool>(
+                    context: context,
+                    builder: (context) {
+                      return AlertDialog(
+                        title: const Text('Close Request'),
+                        content: const Text('Mark this service request as closed?'),
+                        actions: [
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(false),
+                            child: const Text('Cancel'),
+                          ),
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(true),
+                            child: const Text('Confirm'),
+                          ),
+                        ],
+                      );
+                    },
+                  );
+
+                  if (confirmed == true) {
+                    await FirebaseFirestore.instance
+                        .collection('invoices')
+                        .doc(widget.invoiceId)
+                        .update({'status': 'closed'});
+
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Request closed. Thank you for using SkipTow.'),
+                        ),
+                      );
+                      Navigator.pop(context);
+                    }
+                  }
+                },
+                child: const Text('Close Request'),
+              ),
+            ),
+          );
+        }
+
         return Scaffold(
           appBar: AppBar(title: const Text('Invoice Details')),
           body: Padding(

--- a/lib/pages/invoices_page.dart
+++ b/lib/pages/invoices_page.dart
@@ -87,7 +87,11 @@ class _InvoicesPageState extends State<InvoicesPage> {
         if (_selectedFilter == 'active' ||
             _selectedFilter == 'completed' ||
             _selectedFilter == 'cancelled') {
-          query = query.where('status', isEqualTo: _selectedFilter);
+          if (_selectedFilter == 'completed') {
+            query = query.where('status', whereIn: ['completed', 'closed']);
+          } else {
+            query = query.where('status', isEqualTo: _selectedFilter);
+          }
         }
         query = query.orderBy('timestamp', descending: true);
 
@@ -178,6 +182,8 @@ class _InvoiceTile extends StatelessWidget {
     switch (status) {
       case 'completed':
         return Colors.green;
+      case 'closed':
+        return Colors.blueGrey;
       case 'cancelled':
         return Colors.red;
       default:

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -600,7 +600,7 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                   stream: FirebaseFirestore.instance
                       .collection('invoices')
                       .where('mechanicId', isEqualTo: widget.userId)
-                      .where('status', isEqualTo: 'completed')
+                      .where('status', whereIn: ['completed', 'closed'])
                       .snapshots(),
                   builder: (context, snapshot) {
                     final completedCount = snapshot.data?.size ?? 0;

--- a/lib/pages/mechanic_request_queue_page.dart
+++ b/lib/pages/mechanic_request_queue_page.dart
@@ -97,7 +97,11 @@ class _MechanicRequestQueuePageState extends State<MechanicRequestQueuePage> {
             .collection('invoices')
             .where('mechanicId', isEqualTo: widget.mechanicId);
         if (_selectedFilter.isNotEmpty) {
-          query = query.where('status', isEqualTo: _selectedFilter);
+          if (_selectedFilter == 'completed') {
+            query = query.where('status', whereIn: ['completed', 'closed']);
+          } else {
+            query = query.where('status', isEqualTo: _selectedFilter);
+          }
         }
         if (_selectedFilter == 'active') {
           query = query.orderBy(tsField, descending: true);

--- a/lib/pages/notifications_page.dart
+++ b/lib/pages/notifications_page.dart
@@ -65,16 +65,22 @@ class NotificationsPage extends StatelessWidget {
                                     ? "New request received from ${data['customerId']}"
                                     : status == 'completed'
                                         ? 'Request marked as completed.'
-                                        : "Status updated: $status";
+                                        : status == 'closed'
+                                            ? 'Request closed.'
+                                            : "Status updated: $status";
                                 final unread = !readIds.contains(doc.id);
                                 return ListTile(
                                   leading: Icon(
                                     status == 'completed'
                                         ? Icons.check_circle
-                                        : Icons.notifications,
+                                        : status == 'closed'
+                                            ? Icons.archive
+                                            : Icons.notifications,
                                     color: status == 'completed'
                                         ? Colors.green
-                                        : Colors.blue,
+                                        : status == 'closed'
+                                            ? Colors.blueGrey
+                                            : Colors.blue,
                                   ),
                                   title: Text(message),
                                   tileColor:

--- a/lib/pages/service_request_history_page.dart
+++ b/lib/pages/service_request_history_page.dart
@@ -11,6 +11,8 @@ class ServiceRequestHistoryPage extends StatelessWidget {
     switch (status) {
       case 'completed':
         return Colors.green;
+      case 'closed':
+        return Colors.blueGrey;
       case 'cancelled':
         return Colors.red;
       default:


### PR DESCRIPTION
## Summary
- allow customers to close a completed request in **InvoiceDetailPage**
- display closed invoices with a blue‑grey status color
- include `closed` invoices when filtering for completed invoices
- treat closed invoices as completed on dashboards and queues
- update notifications for closed invoices

## Testing
- `dart format lib/pages` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687964570230832f8270b89f35326541