### PR TITLE
Add closedAt timestamp and show on admin

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -218,6 +218,8 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
           Text('Customer: ${data['customerId']}'),
           Text('Status: ${data['status']}'),
           Text('Submitted: ${_formatDate(data['timestamp'])}'),
+          if (data['closedAt'] != null)
+            Text('Closed: ${_formatDate(data['closedAt'])}'),
         ],
       ),
     );

--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -421,7 +421,10 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
                     await FirebaseFirestore.instance
                         .collection('invoices')
                         .doc(widget.invoiceId)
-                        .update({'status': 'closed'});
+                        .update({
+                      'status': 'closed',
+                      'closedAt': FieldValue.serverTimestamp(),
+                    });
 
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Summary
- record `closedAt` timestamp when customers close service requests
- show closed timestamp in admin dashboard invoice list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68796686e500832fb696d4680e39c3f4