### PR TITLE
Display mechanic notes on invoice

### DIFF
--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -184,6 +184,10 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
                   ? 'Final Total: \$${finalPrice.toStringAsFixed(2)}'
                   : 'Final Total: Pending',
             ),
+          if (widget.role == 'customer')
+            (data['postJobNotes'] ?? '').toString().isNotEmpty
+                ? Text('Mechanic Notes:\n${data['postJobNotes']}')
+                : const Text('No mechanic notes provided.'),
           // Show customer contact info only to mechanics
           if (widget.role == 'mechanic' &&
               (data['customerPhone'] ?? '').toString().isNotEmpty)


### PR DESCRIPTION
## Summary
- show `postJobNotes` when customer views an invoice

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687968c579a4832f88b04351de2af0e3