### PR TITLE
Add optional customer review feature

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -234,6 +234,8 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
           Text('Submitted: ${_formatDate(data['timestamp'])}'),
           if (data['closedAt'] != null)
             Text('Closed: ${_formatDate(data['closedAt'])}'),
+          if ((data['customerReview'] ?? '').toString().isNotEmpty)
+            Text('Review: ${data['customerReview']}'),
         ],
       ),
     );

--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -210,6 +210,9 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
           Text('Status: $status'),
           if (finalPrice != null && widget.role != 'customer')
             Text('Final Price: \$${finalPrice.toString()}'),
+          if (widget.role == 'mechanic' &&
+              (data['customerReview'] ?? '').toString().isNotEmpty)
+            Text('Customer Review:\n${data['customerReview']}'),
         ]);
 
         if (widget.role == 'mechanic' && status == 'accepted') {
@@ -440,12 +443,27 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
               alignment: Alignment.centerRight,
               child: ElevatedButton(
                 onPressed: () async {
+                  final reviewController = TextEditingController();
                   final confirmed = await showDialog<bool>(
                     context: context,
                     builder: (context) {
                       return AlertDialog(
                         title: const Text('Close Request'),
-                        content: const Text('Mark this service request as closed?'),
+                        content: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const Text('Mark this service request as closed?'),
+                            const SizedBox(height: 12),
+                            TextField(
+                              controller: reviewController,
+                              minLines: 3,
+                              maxLines: 5,
+                              decoration: const InputDecoration(
+                                labelText: 'Leave a review for your mechanic (optional)',
+                              ),
+                            ),
+                          ],
+                        ),
                         actions: [
                           TextButton(
                             onPressed: () => Navigator.of(context).pop(false),
@@ -461,13 +479,18 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
                   );
 
                   if (confirmed == true) {
+                    final Map<String, dynamic> updateData = {
+                      'status': 'closed',
+                      'closedAt': FieldValue.serverTimestamp(),
+                    };
+                    final review = reviewController.text.trim();
+                    if (review.isNotEmpty) {
+                      updateData['customerReview'] = review;
+                    }
                     await FirebaseFirestore.instance
                         .collection('invoices')
                         .doc(widget.invoiceId)
-                        .update({
-                      'status': 'closed',
-                      'closedAt': FieldValue.serverTimestamp(),
-                    });
+                        .update(updateData);
 
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Summary
- allow customers to leave an optional review when closing a request
- show any review to mechanics in invoice detail page
- show customer review in the admin dashboard invoice list

## Testing
- `dart` not installed, so formatting or building was skipped

------
https://chatgpt.com/codex/tasks/task_e_68796cbfb968832f8ceb150627255ef5