### PR TITLE
Add completed job tracking

### DIFF
--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 /// Page to show full invoice details.
 class InvoiceDetailPage extends StatefulWidget {
@@ -368,10 +369,17 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
                             .collection('invoices')
                             .doc(widget.invoiceId)
                             .update({
-                          'status': 'completed',
-                          'finalPrice': price,
-                          'postJobNotes': notes,
-                        });
+                              'status': 'completed',
+                              'finalPrice': price,
+                              'postJobNotes': notes,
+                            });
+                        final uid = FirebaseAuth.instance.currentUser?.uid;
+                        if (uid != null) {
+                          await FirebaseFirestore.instance
+                              .collection('users')
+                              .doc(uid)
+                              .update({'completedJobs': FieldValue.increment(1)});
+                        }
 
                         if (mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/pages/invoices_page.dart
+++ b/lib/pages/invoices_page.dart
@@ -266,6 +266,10 @@ class _InvoiceTile extends StatelessWidget {
                   .collection('invoices')
                   .doc(invoiceId)
                   .update({'status': 'completed'});
+              await FirebaseFirestore.instance
+                  .collection('users')
+                  .doc(currentUserId)
+                  .update({'completedJobs': FieldValue.increment(1)});
             },
             child: const Text('Mark Completed'),
           ),

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -33,6 +33,7 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
   bool _locationPermissionGranted = false;
   bool _locationBannerVisible = false;
   bool _hasAccountData = true;
+  int completedJobs = 0;
 
   void _showLocationBanner() {
     if (_locationBannerVisible || !mounted) return;
@@ -176,6 +177,7 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
       setState(() {
         isActive = data['isActive'] ?? false;
         radiusMiles = (data['radiusMiles'] ?? 5).toDouble();
+        completedJobs = data['completedJobs'] ?? 0;
         if (data.containsKey('location')) {
           currentPosition = Position(
             latitude: data['location']['lat'],
@@ -596,18 +598,18 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                     );
                   },
                 ),
-                StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+                StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
                   stream: FirebaseFirestore.instance
-                      .collection('invoices')
-                      .where('mechanicId', isEqualTo: widget.userId)
-                      .where('status', whereIn: ['completed', 'closed'])
+                      .collection('users')
+                      .doc(widget.userId)
                       .snapshots(),
                   builder: (context, snapshot) {
-                    final completedCount = snapshot.data?.size ?? 0;
+                    final data = snapshot.data?.data();
+                    final completedCount = data?['completedJobs'] ?? completedJobs;
                     return Padding(
                       padding: const EdgeInsets.all(8),
                       child: Text(
-                        'Completed Jobs: $completedCount',
+                        'Total Completed Jobs: $completedCount',
                         style: const TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.bold,


### PR DESCRIPTION
## Summary
- track total completed jobs per mechanic in Firestore
- increment mechanic `completedJobs` count when marking invoices complete
- show "Total Completed Jobs" on the mechanic dashboard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879701de408832f8f52347b3b5cba46