### PR TITLE
Add flagged invoices count & hide flagged records

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -24,6 +24,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
   int _cancelledInvoices = 0;
   int _platformCompletedJobs = 0;
   int _closedInvoices = 0;
+  int _flaggedInvoices = 0;
   int _totalActiveUsers = 0;
 
   StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _invoiceSub;
@@ -107,6 +108,12 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
         .where('status', isEqualTo: 'closed')
         .get();
     _closedInvoices = closedSnap.size;
+
+    final flaggedSnap = await FirebaseFirestore.instance
+        .collection('invoices')
+        .where('flagged', isEqualTo: true)
+        .get();
+    _flaggedInvoices = flaggedSnap.size;
     if (mounted) setState(() {});
   }
 
@@ -116,8 +123,10 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
     int completed = 0;
     int cancelled = 0;
     int closed = 0;
+    int flagged = 0;
     for (final doc in snapshot.docs) {
-      final status = doc.data()['status'];
+      final data = doc.data();
+      final status = data['status'];
       if (status == 'active') {
         active++;
       } else if (status == 'completed') {
@@ -128,12 +137,14 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
       } else if (status == 'cancelled') {
         cancelled++;
       }
+      if (data['flagged'] == true) flagged++;
     }
     if (!mounted) {
       _activeInvoices = active;
       _completedInvoices = completed;
       _cancelledInvoices = cancelled;
       _closedInvoices = closed;
+      _flaggedInvoices = flagged;
       return;
     }
     setState(() {
@@ -141,6 +152,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
       _completedInvoices = completed;
       _cancelledInvoices = cancelled;
       _closedInvoices = closed;
+      _flaggedInvoices = flagged;
     });
   }
 
@@ -211,6 +223,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
         Text('Active Invoices: $_activeInvoices'),
         Text('Completed Invoices: $_completedInvoices'),
         Text('Cancelled Invoices: $_cancelledInvoices'),
+        Text('Flagged Invoices: $_flaggedInvoices'),
         Text('Platform Completed Jobs: $_platformCompletedJobs'),
         Text('Total Requests Closed: $_closedInvoices'),
       ],

--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -93,9 +93,12 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
         .where('status', isEqualTo: 'accepted')
         .snapshots()
         .listen((snapshot) {
-      if (snapshot.docs.isNotEmpty) {
+      final docs = snapshot.docs
+          .where((d) => d.data()['flagged'] != true)
+          .toList();
+      if (docs.isNotEmpty) {
         _showRequestAcceptedBanner();
-        final data = snapshot.docs.first.data();
+        final data = docs.first.data();
         final mechId = data['mechanicId'] as String?;
         if (mechId != null) {
           _startEtaUpdates(mechId);
@@ -145,7 +148,10 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
         .where('status', whereIn: ['completed', 'closed'])
         .snapshots()
         .listen((snapshot) {
-      if (snapshot.docs.isNotEmpty) {
+      final docs = snapshot.docs
+          .where((d) => d.data()['flagged'] != true)
+          .toList();
+      if (docs.isNotEmpty) {
         _showCompletedBanner();
       } else {
         _hideCompletedBanner();
@@ -612,11 +618,16 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
       stream: stream,
       builder: (context, snapshot) {
-        if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+        final docs = snapshot.hasData
+            ? snapshot.data!.docs
+                .where((d) => d.data()['flagged'] != true)
+                .toList()
+            : <QueryDocumentSnapshot<Map<String, dynamic>>>[];
+        if (docs.isEmpty) {
           return const SizedBox.shrink();
         }
 
-        final data = snapshot.data!.docs.first.data();
+        final data = docs.first.data();
         final car = data['carInfo'] ?? {};
         final year = (car['year'] ?? '').toString();
         final make = (car['make'] ?? '').toString();
@@ -648,7 +659,12 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
       stream: stream,
       builder: (context, snapshot) {
-        if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+        final docs = snapshot.hasData
+            ? snapshot.data!.docs
+                .where((d) => d.data()['flagged'] != true)
+                .toList()
+            : <QueryDocumentSnapshot<Map<String, dynamic>>>[];
+        if (docs.isEmpty) {
           return const SizedBox.shrink();
         }
 
@@ -675,7 +691,12 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
       stream: stream,
       builder: (context, snapshot) {
-        if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+        final docs = snapshot.hasData
+            ? snapshot.data!.docs
+                .where((d) => d.data()['flagged'] != true)
+                .toList()
+            : <QueryDocumentSnapshot<Map<String, dynamic>>>[];
+        if (docs.isEmpty) {
           return const SizedBox.shrink();
         }
 
@@ -923,10 +944,15 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
                         .limit(1)
                         .snapshots(),
                     builder: (context, snapshot) {
-                      if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+                      final docs = snapshot.hasData
+                          ? snapshot.data!.docs
+                              .where((d) => d.data()['flagged'] != true)
+                              .toList()
+                          : <QueryDocumentSnapshot<Map<String, dynamic>>>[];
+                      if (docs.isEmpty) {
                         return const SizedBox.shrink();
                       }
-                      final data = snapshot.data!.docs.first.data();
+                      final data = docs.first.data();
                       final Timestamp? ts = data['createdAt'];
                       if (ts == null) return const SizedBox.shrink();
                       final timeStr =

--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -27,6 +27,7 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
         .get();
     final data = doc.data();
     if (data == null) return null;
+    if (data['flagged'] == true && widget.role != 'admin') return null;
 
     final customerDoc = await FirebaseFirestore.instance
         .collection('users')

--- a/lib/pages/invoices_page.dart
+++ b/lib/pages/invoices_page.dart
@@ -129,7 +129,9 @@ class _InvoicesPageState extends State<InvoicesPage> {
                       return const Center(child: CircularProgressIndicator());
                     }
 
-                    final docs = snapshot.data?.docs ?? [];
+                    final docs = (snapshot.data?.docs ?? [])
+                        .where((d) => d.data()['flagged'] != true)
+                        .toList();
                     if (docs.isEmpty) {
                       return const Center(child: Text('No invoices found'));
                     }

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -331,7 +331,8 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
         return;
       }
       for (final change in snapshot.docChanges) {
-        if (change.type == DocumentChangeType.added) {
+        if (change.type == DocumentChangeType.added &&
+            change.doc.data()?['flagged'] != true) {
           if (mounted) {
             ScaffoldMessenger.of(context).showSnackBar(
               const SnackBar(content: Text('New service request received')),
@@ -585,7 +586,7 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                       .where('status', isEqualTo: 'active')
                       .snapshots(),
                   builder: (context, snapshot) {
-                    final activeCount = snapshot.data?.size ?? 0;
+                    final activeCount = snapshot.hasData ? snapshot.data!.docs.where((d) => d.data()["flagged"] != true).length : 0;
                     return Padding(
                       padding: const EdgeInsets.all(8),
                       child: Text(

--- a/lib/pages/mechanic_request_queue_page.dart
+++ b/lib/pages/mechanic_request_queue_page.dart
@@ -152,7 +152,9 @@ class _MechanicRequestQueuePageState extends State<MechanicRequestQueuePage> {
                     if (snapshot.connectionState == ConnectionState.waiting) {
                       return const Center(child: CircularProgressIndicator());
                     }
-                    final docs = snapshot.data?.docs ?? [];
+                    final docs = (snapshot.data?.docs ?? [])
+                        .where((d) => d.data()['flagged'] != true)
+                        .toList();
                     if (docs.isEmpty) {
                       return const Center(child: Text('No requests found'));
                     }

--- a/lib/pages/service_request_history_page.dart
+++ b/lib/pages/service_request_history_page.dart
@@ -43,7 +43,9 @@ class ServiceRequestHistoryPage extends StatelessWidget {
             return const Center(child: CircularProgressIndicator());
           }
 
-          final docs = snapshot.data?.docs ?? [];
+          final docs = (snapshot.data?.docs ?? [])
+              .where((d) => d.data()['flagged'] != true)
+              .toList();
           if (docs.isEmpty) {
             return const Center(child: Text('No service requests found'));
           }


### PR DESCRIPTION
## Summary
- track flagged invoices for admins
- hide flagged invoices from mechanics and customers
- block invoice details for flagged invoices

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687973c94c04832fb8a35296440c289a