### PR TITLE
Add Pay Now placeholder button

### DIFF
--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -448,7 +448,24 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
         }
 
         if (widget.role == 'customer' && status == 'completed') {
-          children.add(
+          children.addAll([
+            Align(
+              alignment: Alignment.centerRight,
+              child: ElevatedButton(
+                onPressed: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Payment system not yet implemented.'),
+                    ),
+                  );
+                },
+                style: ElevatedButton.styleFrom(
+                  minimumSize: const Size.fromHeight(50),
+                ),
+                child: const Text('Pay Now'),
+              ),
+            ),
+            const SizedBox(height: 12),
             Align(
               alignment: Alignment.centerRight,
               child: ElevatedButton(
@@ -515,7 +532,7 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
                 child: const Text('Close Request'),
               ),
             ),
-          );
+          ]);
         }
 
         return Scaffold(


### PR DESCRIPTION
## Summary
- show new **Pay Now** button on invoice detail page when customers view completed jobs
- show snackbar that payment is not implemented yet

## Testing
- `dartfmt` not required
- `flutter analyze` not run per instructions

------
https://chatgpt.com/codex/tasks/task_e_687978085774832f90203df4be063f39