### PR TITLE
Add placeholder payment processing page

### DIFF
--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'payment_processing_page.dart';
 
 /// Page to show full invoice details.
 class InvoiceDetailPage extends StatefulWidget {
@@ -455,14 +456,11 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
             Align(
               alignment: Alignment.centerRight,
               child: ElevatedButton(
-                onPressed: () async {
-                  await FirebaseFirestore.instance
-                      .collection('invoices')
-                      .doc(widget.invoiceId)
-                      .update({'paymentStatus': 'paid'});
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Payment system not yet implemented.'),
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const PaymentProcessingPage(),
                     ),
                   );
                 },

--- a/lib/pages/payment_processing_page.dart
+++ b/lib/pages/payment_processing_page.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder page that simulates Stripe payment processing.
+class PaymentProcessingPage extends StatefulWidget {
+  const PaymentProcessingPage({super.key});
+
+  @override
+  State<PaymentProcessingPage> createState() => _PaymentProcessingPageState();
+}
+
+class _PaymentProcessingPageState extends State<PaymentProcessingPage> {
+  bool _done = false;
+
+  @override
+  void initState() {
+    super.initState();
+    Future.delayed(const Duration(seconds: 3), () {
+      if (mounted) {
+        setState(() {
+          _done = true;
+        });
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Payment')),
+      body: Center(
+        child: !_done
+            ? Column(
+                mainAxisSize: MainAxisSize.min,
+                children: const [
+                  CircularProgressIndicator(),
+                  SizedBox(height: 16),
+                  Text('Processing payment via Stripe…'),
+                ],
+              )
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text('Payment successful (placeholder).'),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('Return to Invoice'),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `PaymentProcessingPage` that fakes Stripe processing
- link the 'Pay Now' button in `InvoiceDetailPage` to this new page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68797c7b22a4832fb3466415d2a506da