### PR TITLE
Display invoice number in admin list items

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -380,11 +380,19 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
     return Container(
       color: overdue ? Colors.red.shade50 : null,
       child: ListTile(
-        title: Text('Mechanic: ${data['mechanicId']}'),
+        title: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text('Mechanic: ${data['mechanicId']}'),
+            Text(
+              'Invoice #: ${data['invoiceNumber'] ?? doc.id}',
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+          ],
+        ),
         subtitle: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Invoice #: ${data['invoiceNumber'] ?? doc.id}'),
             Text('Customer: ${data['customerId']}'),
             Text('Status: ${data['status']}'),
             Row(


### PR DESCRIPTION
## Summary
- show invoice number alongside mechanic name on admin dashboard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68798e7f984c832fa13ed195ccc24342