### PR TITLE
Display invoice numbers more prominently

### DIFF
--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -150,9 +150,9 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
           Padding(
             padding: const EdgeInsets.only(bottom: 8),
             child: Text(
-              'Invoice #: ' + invoiceNum,
+              'Service Request #: $invoiceNum',
               style: const TextStyle(
-                fontSize: 16,
+                fontSize: 20,
                 fontWeight: FontWeight.bold,
               ),
             ),


### PR DESCRIPTION
## Summary
- show invoice/service request numbers more prominently at the top of the invoice details page for customer and mechanic views

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68798fe9e258832fb7c99d9c08476124