### PR TITLE
Add overdue filter

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -408,11 +408,14 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
               ],
             ),
             if (overdue)
-              const Text(
-                '⚠️ Overdue Payment',
-                style: TextStyle(
-                  color: Colors.red,
-                  fontWeight: FontWeight.bold,
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Chip(
+                  label: const Text(
+                    'OVERDUE',
+                    style: TextStyle(color: Colors.white),
+                  ),
+                  backgroundColor: Colors.red,
                 ),
               ),
             Text('Submitted: ${_formatDate(data['timestamp'])}'),


### PR DESCRIPTION
## Summary
- highlight overdue invoices with a red chip
- filter for overdue invoices in admin dashboard

## Testing
- `dart` not available; formatting skipped

------
https://chatgpt.com/codex/tasks/task_e_68799459d884832f90e382e5f1c8a775