### PR TITLE
Add platform revenue estimate to admin dashboard

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -38,6 +38,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
   double _monthlyCollected = 0.0;
   double _monthlyServiceTotal = 0.0;
   double _monthlyPayoutEstimate = 0.0;
+  double _platformRevenueEstimate = 0.0;
   int _monthlyInvoices = 0;
 
   // Cache of userId to username for quick lookups
@@ -192,6 +193,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
       }
     }
     _monthlyServiceTotal = monthlyServiceTotal;
+    _platformRevenueEstimate = monthlyServiceTotal * 0.15;
 
     final paidSnap = await FirebaseFirestore.instance
         .collection('invoices')
@@ -335,6 +337,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
       _totalPaidAmount = total;
       _monthlyCollected = monthlyTotal;
       _monthlyServiceTotal = monthlyServiceTotal;
+      _platformRevenueEstimate = monthlyServiceTotal * 0.15;
       _monthlyPayoutEstimate = monthlyPayout * 0.85;
       _averagePaidAmount = avg;
       _unpaidOutstanding = pendingTotal;
@@ -353,6 +356,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
       _totalPaidAmount = total;
       _monthlyCollected = monthlyTotal;
       _monthlyServiceTotal = monthlyServiceTotal;
+      _platformRevenueEstimate = monthlyServiceTotal * 0.15;
       _monthlyPayoutEstimate = monthlyPayout * 0.85;
       _averagePaidAmount = avg;
       _unpaidOutstanding = pendingTotal;
@@ -468,6 +472,10 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
         Text(
           'Total Service Value This Month: '
           '${NumberFormat.currency(locale: 'en_US', symbol: '\$').format(_monthlyServiceTotal)}',
+        ),
+        Text(
+          'Estimated Platform Revenue This Month: '
+          '${NumberFormat.currency(locale: 'en_US', symbol: '\$').format(_platformRevenueEstimate)}',
         ),
         Text(
           'Average Payment Per Job: '


### PR DESCRIPTION
## Summary
- calculate monthly platform revenue as 15% of service totals
- update stats in admin dashboard to show this estimate

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6879a20e629c832fb2745ccf5f698ec3