### PR TITLE
Add Job History button in mechanic dashboard

### DIFF
--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -9,6 +9,7 @@ import 'package:skiptow/services/error_logger.dart';
 import 'invoices_page.dart';
 import 'messages_page.dart';
 import 'mechanic_request_queue_page.dart';
+import 'mechanic_job_history_page.dart';
 
 BitmapDescriptor? wrenchIcon;
 
@@ -564,6 +565,20 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                 context,
                 MaterialPageRoute(
                   builder: (_) => MechanicRequestQueuePage(
+                    mechanicId: widget.userId,
+                  ),
+                ),
+              );
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.history),
+            tooltip: 'Job History',
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => MechanicJobHistoryPage(
                     mechanicId: widget.userId,
                   ),
                 ),


### PR DESCRIPTION
## Summary
- import mechanic job history page
- add a Job History button to the mechanic dashboard

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687a4ad9be98832fb97e9c2efdca66bf