### PR TITLE
TASK 54B Add mechanic unblocking

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -463,6 +463,19 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
     }
   }
 
+  Future<void> _unblockMechanic(String mechId) async {
+    await FirebaseFirestore.instance
+        .collection('users')
+        .doc(mechId)
+        .update({'blocked': false});
+    await _loadStats();
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Mechanic unblocked')),
+      );
+    }
+  }
+
   Future<void> _loadAppVersion() async {
     try {
       final info = await PackageInfo.fromPlatform();
@@ -854,8 +867,8 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                 title: Text(d.data()['username'] ?? d.id),
                 subtitle: Text(d.id),
                 trailing: TextButton(
-                  onPressed: null, // TODO: implement unblocking
-                  child: const Text('Unblock'),
+                  onPressed: () => _unblockMechanic(d.id),
+                  child: const Text('Unblock Mechanic'),
                 ),
               );
             }).toList(),

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -684,6 +684,16 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                   builder: (context, snapshot) {
                     final data = snapshot.data?.data();
                     final completedCount = data?['completedJobs'] ?? completedJobs;
+                    final blocked = data?['blocked'] == true;
+                    if (blocked != _blocked) {
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        if (mounted) {
+                          setState(() {
+                            _blocked = blocked;
+                          });
+                        }
+                      });
+                    }
                     return Padding(
                       padding: const EdgeInsets.all(8),
                       child: Text(


### PR DESCRIPTION
## Summary
- add `_unblockMechanic` to admin dashboard
- enable Unblock button in Blocked Mechanics list
- watch mechanic document for blocked updates so dashboard access returns instantly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a55ce2558832f9f7c720230a75bc7