### PR TITLE
Add profile nav to customer dashboard

### DIFF
--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -10,6 +10,7 @@ import 'dart:async';
 import 'service_request_history_page.dart';
 import 'messages_page.dart';
 import 'customer_invoices_page.dart';
+import 'customer_profile_page.dart';
 
 class CustomerDashboard extends StatefulWidget {
   final String userId;
@@ -919,6 +920,23 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
             icon: const Icon(Icons.receipt, color: Colors.white),
             label: const Text(
               'My Invoices',
+              style: TextStyle(color: Colors.white),
+            ),
+          ),
+          TextButton.icon(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => CustomerProfilePage(
+                    userId: widget.userId,
+                  ),
+                ),
+              );
+            },
+            icon: const Icon(Icons.person, color: Colors.white),
+            label: const Text(
+              'Profile',
               style: TextStyle(color: Colors.white),
             ),
           ),


### PR DESCRIPTION
## Summary
- import profile page in customer dashboard
- add `Profile` button in app bar navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a724e4870832f819727cb8f025a86