### PR TITLE
Add profile button to mechanic dashboard

### DIFF
--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -10,6 +10,7 @@ import 'invoices_page.dart';
 import 'messages_page.dart';
 import 'mechanic_request_queue_page.dart';
 import 'mechanic_job_history_page.dart';
+import 'mechanic_profile_page.dart';
 
 BitmapDescriptor? wrenchIcon;
 
@@ -601,6 +602,21 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                       ),
                     );
                   },
+          ),
+          TextButton.icon(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => MechanicProfilePage(userId: widget.userId),
+                ),
+              );
+            },
+            icon: const Icon(Icons.person, color: Colors.white),
+            label: const Text(
+              'Profile',
+              style: TextStyle(color: Colors.white),
+            ),
           ),
           _buildMessagesIcon(),
         ],


### PR DESCRIPTION
## Summary
- import mechanic_profile_page.dart
- add a `Profile` button in the mechanic dashboard app bar

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687a76c1cf84832fa50a45e7730d0696