### PR TITLE
Add blocked accounts count

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -30,6 +30,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
   int _blockedMechanics = 0;
   int _flaggedMechanics = 0;
   int _flaggedCustomers = 0;
+  int _blockedUsers = 0;
   int _totalActiveUsers = 0;
   int _newCustomers = 0;
   int _newMechanics = 0;
@@ -163,6 +164,9 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
     _blockedMechanics = usersSnapshot.docs
         .where((d) =>
             d.data()['role'] == 'mechanic' && d.data()['blocked'] == true)
+        .length;
+    _blockedUsers = usersSnapshot.docs
+        .where((d) => d.data()['blocked'] == true)
         .length;
     _flaggedMechanics = usersSnapshot.docs
         .where((d) =>
@@ -422,6 +426,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
     int mechCount = 0;
     int newCount = 0;
     int blockedCount = 0;
+    int blockedCustomerCount = 0;
     int flaggedCount = 0;
     int flaggedCustomerCount = 0;
     final Map<String, String> nameMap = {};
@@ -439,6 +444,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
         if (data['flagged'] == true) flaggedCount++;
       } else if (role == 'customer') {
         count++;
+        if (data['blocked'] == true) blockedCustomerCount++;
         if (data['flagged'] == true) flaggedCustomerCount++;
         final Timestamp? ts = data['createdAt'];
         if (ts != null) {
@@ -450,12 +456,14 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
         }
       }
     }
+    final totalBlocked = blockedCount + blockedCustomerCount;
     if (!mounted) {
       _totalActiveUsers = count;
       _activeMechanics = mechCount;
       _usernames = nameMap;
       _newCustomers = newCount;
       _blockedMechanics = blockedCount;
+      _blockedUsers = totalBlocked;
       _flaggedMechanics = flaggedCount;
       _flaggedCustomers = flaggedCustomerCount;
       return;
@@ -466,6 +474,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
       _usernames = nameMap;
       _newCustomers = newCount;
       _blockedMechanics = blockedCount;
+      _blockedUsers = totalBlocked;
       _flaggedMechanics = flaggedCount;
       _flaggedCustomers = flaggedCustomerCount;
     });
@@ -579,6 +588,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
         Text('Total Users: $_totalUsers'),
         Text('Active Mechanics Right Now: $_activeMechanics'),
         Text('Blocked Mechanics: $_blockedMechanics'),
+        Text('Blocked Accounts: $_blockedUsers'),
         Text('Flagged Mechanics: $_flaggedMechanics'),
         Text('Flagged Customers: $_flaggedCustomers'),
         Text('Total Active Users: $_totalActiveUsers'),


### PR DESCRIPTION
## Summary
- show total blocked accounts in `AdminDashboardPage`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687a82c5575c832f9bf93fabd56889fb