### PR TITLE
Add admin user detail page

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -6,6 +6,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:intl/intl.dart';
 import 'login_page.dart';
 import 'dashboard_page.dart';
+import 'admin_user_detail_page.dart';
 
 /// Simple admin dashboard for monitoring the platform.
 class AdminDashboardPage extends StatefulWidget {
@@ -959,6 +960,18 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     IconButton(
+                      icon: const Icon(Icons.info_outline),
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => AdminUserDetailPage(userId: d.id),
+                          ),
+                        );
+                      },
+                      tooltip: 'View Details',
+                    ),
+                    IconButton(
                       icon: const Icon(Icons.block),
                       onPressed: () => _deactivateMechanic(d.id),
                       tooltip: 'Deactivate',
@@ -1023,9 +1036,26 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                   ],
                 ),
                 subtitle: Text(d.id),
-                trailing: TextButton(
-                  onPressed: () => _unblockMechanic(d.id),
-                  child: const Text('Unblock Mechanic'),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.info_outline),
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => AdminUserDetailPage(userId: d.id),
+                          ),
+                        );
+                      },
+                      tooltip: 'View Details',
+                    ),
+                    TextButton(
+                      onPressed: () => _unblockMechanic(d.id),
+                      child: const Text('Unblock Mechanic'),
+                    ),
+                  ],
                 ),
               );
             }).toList(),
@@ -1081,9 +1111,26 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                   ],
                 ),
                 subtitle: Text(d.id),
-                trailing: TextButton(
-                  onPressed: () => _unflagMechanic(d.id),
-                  child: const Text('Remove Flag'),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.info_outline),
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => AdminUserDetailPage(userId: d.id),
+                          ),
+                        );
+                      },
+                      tooltip: 'View Details',
+                    ),
+                    TextButton(
+                      onPressed: () => _unflagMechanic(d.id),
+                      child: const Text('Remove Flag'),
+                    ),
+                  ],
                 ),
               );
             }).toList(),
@@ -1142,6 +1189,18 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                 trailing: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
+                    IconButton(
+                      icon: const Icon(Icons.info_outline),
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => AdminUserDetailPage(userId: d.id),
+                          ),
+                        );
+                      },
+                      tooltip: 'View Details',
+                    ),
                     if (flagged)
                       const Icon(
                         Icons.flag,
@@ -1207,9 +1266,26 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                   ],
                 ),
                 subtitle: Text(d.id),
-                trailing: TextButton(
-                  onPressed: () => _unflagCustomer(d.id),
-                  child: const Text('Remove Flag'),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.info_outline),
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => AdminUserDetailPage(userId: d.id),
+                          ),
+                        );
+                      },
+                      tooltip: 'View Details',
+                    ),
+                    TextButton(
+                      onPressed: () => _unflagCustomer(d.id),
+                      child: const Text('Remove Flag'),
+                    ),
+                  ],
                 ),
               );
             }).toList(),

--- a/lib/pages/admin_user_detail_page.dart
+++ b/lib/pages/admin_user_detail_page.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:intl/intl.dart';
+
+/// Displays detailed account information for any user.
+class AdminUserDetailPage extends StatefulWidget {
+  final String userId;
+
+  const AdminUserDetailPage({super.key, required this.userId});
+
+  @override
+  State<AdminUserDetailPage> createState() => _AdminUserDetailPageState();
+}
+
+class _AdminUserDetailPageState extends State<AdminUserDetailPage> {
+  late Future<Map<String, dynamic>> _detailsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _detailsFuture = _loadDetails();
+  }
+
+  Future<Map<String, dynamic>> _loadDetails() async {
+    final userDoc = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(widget.userId)
+        .get();
+    final userData = userDoc.data() ?? {};
+    final role = userData['role'] ?? 'customer';
+
+    int completedJobs = 0;
+    double totalEarnings = 0.0;
+    int totalRequests = 0;
+    double totalPaid = 0.0;
+
+    if (role == 'mechanic') {
+      final invoicesSnap = await FirebaseFirestore.instance
+          .collection('invoices')
+          .where('mechanicId', isEqualTo: widget.userId)
+          .get();
+      for (final doc in invoicesSnap.docs) {
+        final data = doc.data();
+        if (data['flagged'] == true) continue;
+        final status = data['status'];
+        if (status == 'completed' || status == 'closed') {
+          completedJobs++;
+        }
+        if (data['paymentStatus'] == 'paid') {
+          totalEarnings += (data['finalPrice'] as num?)?.toDouble() ?? 0.0;
+        }
+      }
+    } else {
+      final invoicesSnap = await FirebaseFirestore.instance
+          .collection('invoices')
+          .where('customerId', isEqualTo: widget.userId)
+          .get();
+      for (final doc in invoicesSnap.docs) {
+        final data = doc.data();
+        if (data['flagged'] == true) continue;
+        totalRequests++;
+        if (data['paymentStatus'] == 'paid') {
+          totalPaid += (data['finalPrice'] as num?)?.toDouble() ?? 0.0;
+        }
+      }
+    }
+
+    return {
+      'username': userData['username'] ?? 'Unknown',
+      'email': userData['email'] ?? 'Unknown',
+      'createdAt': userData['createdAt'],
+      'role': role,
+      'blocked': userData['blocked'] == true,
+      'flagged': userData['flagged'] == true,
+      'completedJobs': completedJobs,
+      'totalEarnings': totalEarnings,
+      'totalRequests': totalRequests,
+      'totalPaid': totalPaid,
+    };
+  }
+
+  String _formatDate(Timestamp? ts) {
+    if (ts == null) return 'N/A';
+    final dt = ts.toDate().toLocal();
+    return DateFormat('MMMM d, yyyy').format(dt);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('User Details')),
+      body: FutureBuilder<Map<String, dynamic>>(
+        future: _detailsFuture,
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            return const Center(child: Text('User not found'));
+          }
+
+          final data = snapshot.data!;
+          final role = data['role'] ?? 'customer';
+
+          final List<Widget> children = [
+            Text('Username: ${data['username']}'),
+            Text('User ID: ${widget.userId}'),
+            Text('Email: ${data['email']}'),
+            Text('Role: $role'),
+            Text('Account Created: ${_formatDate(data['createdAt'] as Timestamp?)}'),
+            Text('Blocked: ${data['blocked'] == true ? 'Yes' : 'No'}'),
+            Text('Flagged: ${data['flagged'] == true ? 'Yes' : 'No'}'),
+            const SizedBox(height: 20),
+          ];
+
+          if (role == 'mechanic') {
+            children.addAll([
+              Text('Total Jobs Completed: ${data['completedJobs']}'),
+              Text('Total Earnings: \$${(data['totalEarnings'] as double).toStringAsFixed(2)}'),
+            ]);
+          } else {
+            children.addAll([
+              Text('Total Service Requests: ${data['totalRequests']}'),
+              Text('Total Amount Paid: \$${(data['totalPaid'] as double).toStringAsFixed(2)}'),
+            ]);
+          }
+
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: children,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `AdminUserDetailPage` to show account details
- link new page from admin dashboard user lists via View Details buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a86ef4938832f8dc8340fcc68706c