### PR TITLE
Add flag toggle to admin user detail

### DIFF
--- a/lib/pages/admin_user_detail_page.dart
+++ b/lib/pages/admin_user_detail_page.dart
@@ -15,6 +15,7 @@ class AdminUserDetailPage extends StatefulWidget {
 class _AdminUserDetailPageState extends State<AdminUserDetailPage> {
   late Future<Map<String, dynamic>> _detailsFuture;
   bool _isBlocked = false;
+  bool _isFlagged = false;
 
   @override
   void initState() {
@@ -31,6 +32,7 @@ class _AdminUserDetailPageState extends State<AdminUserDetailPage> {
     final role = userData['role'] ?? 'customer';
     setState(() {
       _isBlocked = userData['blocked'] == true;
+      _isFlagged = userData['flagged'] == true;
     });
 
     int completedJobs = 0;
@@ -101,6 +103,18 @@ class _AdminUserDetailPageState extends State<AdminUserDetailPage> {
     });
   }
 
+  Future<void> _toggleFlag() async {
+    final newStatus = !_isFlagged;
+    await FirebaseFirestore.instance
+        .collection('users')
+        .doc(widget.userId)
+        .update({'flagged': newStatus});
+    setState(() {
+      _isFlagged = newStatus;
+      _detailsFuture = _loadDetails();
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -130,6 +144,11 @@ class _AdminUserDetailPageState extends State<AdminUserDetailPage> {
             ElevatedButton(
               onPressed: _toggleBlock,
               child: Text(_isBlocked ? 'Unblock Account' : 'Block Account'),
+            ),
+            const SizedBox(height: 10),
+            ElevatedButton(
+              onPressed: _toggleFlag,
+              child: Text(_isFlagged ? 'Remove Flag' : 'Flag Account'),
             ),
             const SizedBox(height: 20),
           ];


### PR DESCRIPTION
## Summary
- add `_isFlagged` state and toggle
- show Flag/Remove Flag button in admin user detail page

## Testing
- `dart` tooling is unavailable so formatting/tests were skipped

------
https://chatgpt.com/codex/tasks/task_e_687af55a7f74832fb3a1dbb77784043e