### PR TITLE
Show account status warnings on admin detail page

### DIFF
--- a/lib/pages/admin_user_detail_page.dart
+++ b/lib/pages/admin_user_detail_page.dart
@@ -132,7 +132,47 @@ class _AdminUserDetailPageState extends State<AdminUserDetailPage> {
           final data = snapshot.data!;
           final role = data['role'] ?? 'customer';
 
-          final List<Widget> children = [
+          final List<Widget> children = [];
+
+          if (_isBlocked) {
+            children.add(
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(8),
+                color: Colors.red,
+                child: const Text(
+                  '🚫 BLOCKED ACCOUNT',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+            children.add(const SizedBox(height: 8));
+          }
+
+          if (_isFlagged) {
+            children.add(
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(8),
+                color: Colors.yellow,
+                child: const Text(
+                  '⚠️ FLAGGED ACCOUNT',
+                  style: TextStyle(
+                    color: Colors.black,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+            children.add(const SizedBox(height: 8));
+          }
+
+          children.addAll([
             Text('Username: ${data['username']}'),
             Text('User ID: ${widget.userId}'),
             Text('Email: ${data['email']}'),


### PR DESCRIPTION
## Summary
- highlight blocked or flagged account statuses at the top of **AdminUserDetailPage**

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_687b8753375c832fafa9327f85bfb69e