### PR TITLE
Add mechanic performance summary

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -10,6 +10,7 @@ import 'dashboard_page.dart';
 import 'admin_user_detail_page.dart';
 import 'admin_financial_report_page.dart';
 import 'admin_invoice_detail_page.dart';
+import 'admin_mechanic_performance_page.dart';
 
 /// Simple admin dashboard for monitoring the platform.
 class AdminDashboardPage extends StatefulWidget {
@@ -1168,7 +1169,28 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
           if (created != null) Text('Created: ${_formatPrettyDate(created)}'),
         ],
       ),
-      trailing: _buildStatusBadges(data),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (data['role'] == 'mechanic')
+            IconButton(
+              icon: const Icon(Icons.bar_chart),
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => AdminMechanicPerformancePage(
+                      mechanicId: doc.id,
+                      userId: widget.userId,
+                    ),
+                  ),
+                );
+              },
+              tooltip: 'View Performance',
+            ),
+          _buildStatusBadges(data),
+        ],
+      ),
     );
   }
 
@@ -1311,6 +1333,21 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                   children: [
                     _buildStatusBadges(data),
                     IconButton(
+                      icon: const Icon(Icons.bar_chart),
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => AdminMechanicPerformancePage(
+                              mechanicId: d.id,
+                              userId: widget.userId,
+                            ),
+                          ),
+                        );
+                      },
+                      tooltip: 'View Performance',
+                    ),
+                    IconButton(
                       icon: const Icon(Icons.info_outline),
                       onPressed: () {
                         Navigator.push(
@@ -1388,6 +1425,21 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                   children: [
                     _buildStatusBadges(data),
                     IconButton(
+                      icon: const Icon(Icons.bar_chart),
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => AdminMechanicPerformancePage(
+                              mechanicId: d.id,
+                              userId: widget.userId,
+                            ),
+                          ),
+                        );
+                      },
+                      tooltip: 'View Performance',
+                    ),
+                    IconButton(
                       icon: const Icon(Icons.info_outline),
                       onPressed: () {
                         Navigator.push(
@@ -1460,6 +1512,21 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     _buildStatusBadges(data),
+                    IconButton(
+                      icon: const Icon(Icons.bar_chart),
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => AdminMechanicPerformancePage(
+                              mechanicId: d.id,
+                              userId: widget.userId,
+                            ),
+                          ),
+                        );
+                      },
+                      tooltip: 'View Performance',
+                    ),
                     IconButton(
                       icon: const Icon(Icons.info_outline),
                       onPressed: () {

--- a/lib/pages/admin_mechanic_performance_page.dart
+++ b/lib/pages/admin_mechanic_performance_page.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:intl/intl.dart';
+import 'package:charts_flutter/flutter.dart' as charts;
+
+import 'dashboard_page.dart';
+
+class AdminMechanicPerformancePage extends StatefulWidget {
+  final String mechanicId;
+  final String userId;
+  const AdminMechanicPerformancePage({
+    super.key,
+    required this.mechanicId,
+    required this.userId,
+  });
+
+  @override
+  State<AdminMechanicPerformancePage> createState() => _AdminMechanicPerformancePageState();
+}
+
+class _MonthEarnings {
+  final DateTime month;
+  final double total;
+  _MonthEarnings(this.month, this.total);
+}
+
+class _AdminMechanicPerformancePageState extends State<AdminMechanicPerformancePage> {
+  late Future<Map<String, dynamic>> _statsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _statsFuture = _loadStats();
+  }
+
+  Future<String?> _getRole() async {
+    final doc = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(widget.userId)
+        .get();
+    return doc.data()?['role'] as String?;
+  }
+
+  Future<Map<String, dynamic>> _loadStats() async {
+    final userDoc = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(widget.mechanicId)
+        .get();
+    final userData = userDoc.data() ?? {};
+
+    final invoices = await FirebaseFirestore.instance
+        .collection('invoices')
+        .where('mechanicId', isEqualTo: widget.mechanicId)
+        .get();
+
+    int completed = 0;
+    int overdue = 0;
+    int paidCount = 0;
+    double totalPaid = 0.0;
+    double highest = 0.0;
+    double fees = 0.0;
+
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month - 11, 1);
+    final Map<int, double> monthTotals = {};
+    for (int i = 0; i < 12; i++) {
+      final m = DateTime(now.year, now.month - i, 1);
+      monthTotals[m.year * 100 + m.month] = 0.0;
+    }
+
+    for (final doc in invoices.docs) {
+      final data = doc.data();
+      final status = (data['status'] ?? '') as String;
+      final paymentStatus = (data['paymentStatus'] ?? 'pending') as String;
+      final price = (data['finalPrice'] as num?)?.toDouble() ?? 0.0;
+      final Timestamp? createdAtTs = data['createdAt'];
+
+      if (status == 'completed' || status == 'closed') {
+        completed++;
+      }
+
+      if (paymentStatus == 'paid') {
+        paidCount++;
+        totalPaid += price;
+        if (price > highest) highest = price;
+        fees += (data['platformFee'] as num?)?.toDouble() ?? price * 0.15;
+
+        final Timestamp? closedTs = data['closedAt'];
+        final date = (closedTs ?? createdAtTs)?.toDate();
+        if (date != null && !date.isBefore(start)) {
+          final key = date.year * 100 + date.month;
+          if (monthTotals.containsKey(key)) {
+            monthTotals[key] = monthTotals[key]! + price;
+          }
+        }
+      } else if (paymentStatus == 'pending' &&
+          createdAtTs != null &&
+          DateTime.now().difference(createdAtTs.toDate()).inDays > 7) {
+        overdue++;
+      }
+    }
+
+    final avg = paidCount > 0 ? totalPaid / paidCount : 0.0;
+    final List<_MonthEarnings> months = [];
+    for (int i = 11; i >= 0; i--) {
+      final m = DateTime(now.year, now.month - i, 1);
+      final key = m.year * 100 + m.month;
+      months.add(_MonthEarnings(m, monthTotals[key] ?? 0));
+    }
+
+    return {
+      'username': userData['username'] ?? 'Unknown',
+      'createdAt': userData['createdAt'],
+      'blocked': userData['blocked'] == true,
+      'flagged': userData['flagged'] == true,
+      'totalJobs': completed,
+      'totalEarnings': totalPaid,
+      'platformFees': fees,
+      'averagePayment': avg,
+      'highestPayment': highest,
+      'overdueInvoices': overdue,
+      'months': months,
+    };
+  }
+
+  String _currency(double value) {
+    return NumberFormat.currency(locale: 'en_US', symbol: '\$').format(value);
+  }
+
+  String _formatDate(Timestamp? ts) {
+    if (ts == null) return 'N/A';
+    final dt = ts.toDate().toLocal();
+    return DateFormat('MMMM d, yyyy').format(dt);
+  }
+
+  Widget _statItem(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: const TextStyle(fontSize: 16)),
+          Text(
+            value,
+            style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChart(List<_MonthEarnings> months) {
+    final series = [
+      charts.Series<_MonthEarnings, String>(
+        id: 'Earnings',
+        colorFn: (_, __) => charts.MaterialPalette.blue.shadeDefault,
+        domainFn: (d, _) => DateFormat('MMM').format(d.month),
+        measureFn: (d, _) => d.total,
+        data: months,
+      )
+    ];
+    return SizedBox(
+      height: 200,
+      child: charts.BarChart(series, animate: true),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<String?>(
+      future: _getRole(),
+      builder: (context, roleSnap) {
+        if (!roleSnap.hasData) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        if (roleSnap.data != 'admin') {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Access denied.')),
+              );
+              Navigator.pushAndRemoveUntil(
+                context,
+                MaterialPageRoute(builder: (_) => DashboardPage(userId: widget.userId)),
+                (route) => false,
+              );
+            }
+          });
+          return const SizedBox.shrink();
+        }
+
+        return Scaffold(
+          appBar: AppBar(title: const Text('Mechanic Performance')),
+          body: FutureBuilder<Map<String, dynamic>>(
+            future: _statsFuture,
+            builder: (context, snapshot) {
+              if (!snapshot.hasData) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              final data = snapshot.data!;
+              final months = data['months'] as List<_MonthEarnings>;
+              return ListView(
+                padding: const EdgeInsets.all(16),
+                children: [
+                  Text('Mechanic Username: ${data['username']}'),
+                  Text('User ID: ${widget.mechanicId}'),
+                  Text('Registration Date: ${_formatDate(data['createdAt'] as Timestamp?)}'),
+                  Text('Blocked: ${data['blocked'] ? 'Yes' : 'No'}'),
+                  Text('Flagged: ${data['flagged'] ? 'Yes' : 'No'}'),
+                  const SizedBox(height: 16),
+                  _statItem('Total Jobs Completed', '${data['totalJobs']}'),
+                  _statItem('Total Earnings Paid Out', _currency(data['totalEarnings'] as double)),
+                  _statItem('Platform Fees Generated', _currency(data['platformFees'] as double)),
+                  _statItem('Average Payment Per Job', _currency(data['averagePayment'] as double)),
+                  _statItem('Highest Single Payment', _currency(data['highestPayment'] as double)),
+                  _statItem('Number of Overdue Invoices', '${data['overdueInvoices']}'),
+                  const SizedBox(height: 16),
+                  _buildChart(months),
+                ],
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- allow admins to open mechanic performance view from listings
- implement AdminMechanicPerformancePage showing payout stats and chart

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bd6c4b58c832fb78b7b36f19cb9b9