### PR TITLE
Add admin customer history page

### DIFF
--- a/lib/pages/admin_customer_history_page.dart
+++ b/lib/pages/admin_customer_history_page.dart
@@ -1,0 +1,241 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:intl/intl.dart';
+
+import 'dashboard_page.dart';
+
+class AdminCustomerHistoryPage extends StatefulWidget {
+  final String customerId;
+  final String userId;
+  const AdminCustomerHistoryPage({
+    super.key,
+    required this.customerId,
+    required this.userId,
+  });
+
+  @override
+  State<AdminCustomerHistoryPage> createState() => _AdminCustomerHistoryPageState();
+}
+
+class _AdminCustomerHistoryPageState extends State<AdminCustomerHistoryPage> {
+  late Future<Map<String, dynamic>> _statsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _statsFuture = _loadStats();
+  }
+
+  Future<String?> _getRole() async {
+    final doc = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(widget.userId)
+        .get();
+    return doc.data()?['role'] as String?;
+  }
+
+  Future<Map<String, dynamic>> _loadStats() async {
+    final userDoc = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(widget.customerId)
+        .get();
+    final userData = userDoc.data() ?? {};
+
+    final invoicesSnap = await FirebaseFirestore.instance
+        .collection('invoices')
+        .where('customerId', isEqualTo: widget.customerId)
+        .orderBy('createdAt', descending: true)
+        .get();
+
+    int totalRequests = 0;
+    int paidInvoices = 0;
+    int overdueInvoices = 0;
+    int pendingInvoices = 0;
+    double totalSpent = 0.0;
+    double highestPayment = 0.0;
+
+    for (final doc in invoicesSnap.docs) {
+      final data = doc.data();
+      if (data['flagged'] == true) continue;
+      totalRequests++;
+      final price = (data['finalPrice'] as num?)?.toDouble() ?? 0.0;
+      final paymentStatus = (data['paymentStatus'] ?? 'pending') as String;
+      final Timestamp? createdAtTs = data['createdAt'];
+      if (paymentStatus == 'paid') {
+        paidInvoices++;
+        totalSpent += price;
+        if (price > highestPayment) highestPayment = price;
+      } else {
+        if (createdAtTs != null &&
+            DateTime.now().difference(createdAtTs.toDate()).inDays > 7) {
+          overdueInvoices++;
+        } else {
+          pendingInvoices++;
+        }
+      }
+    }
+
+    return {
+      'username': userData['username'] ?? 'Unknown',
+      'createdAt': userData['createdAt'],
+      'blocked': userData['blocked'] == true,
+      'flagged': userData['flagged'] == true,
+      'totalRequests': totalRequests,
+      'totalSpent': totalSpent,
+      'paidInvoices': paidInvoices,
+      'overdueInvoices': overdueInvoices,
+      'pendingInvoices': pendingInvoices,
+      'highestPayment': highestPayment,
+      'invoices': invoicesSnap.docs,
+    };
+  }
+
+  Color _statusColor(String status) {
+    switch (status) {
+      case 'paid':
+        return Colors.green;
+      case 'overdue':
+        return Colors.red;
+      case 'closed':
+        return Colors.blueGrey;
+      default:
+        return Colors.orange;
+    }
+  }
+
+  String _formatDate(Timestamp? ts) {
+    if (ts == null) return 'N/A';
+    final dt = ts.toDate().toLocal();
+    return DateFormat('MMMM d, yyyy').format(dt);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<String?>(
+      future: _getRole(),
+      builder: (context, roleSnap) {
+        if (!roleSnap.hasData) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        if (roleSnap.data != 'admin') {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Access denied.')),
+              );
+              Navigator.pushAndRemoveUntil(
+                context,
+                MaterialPageRoute(builder: (_) => DashboardPage(userId: widget.userId)),
+                (route) => false,
+              );
+            }
+          });
+          return const SizedBox.shrink();
+        }
+
+        return Scaffold(
+          appBar: AppBar(title: const Text('Customer History')),
+          body: FutureBuilder<Map<String, dynamic>>(
+            future: _statsFuture,
+            builder: (context, snapshot) {
+              if (!snapshot.hasData) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              final data = snapshot.data!;
+              final invoices = data['invoices'] as List<QueryDocumentSnapshot<Map<String, dynamic>>>;
+              return ListView(
+                padding: const EdgeInsets.all(16),
+                children: [
+                  Text('Customer Username: ${data['username']}'),
+                  Text('User ID: ${widget.customerId}'),
+                  Text('Registration Date: ${_formatDate(data['createdAt'] as Timestamp?)}'),
+                  Text('Blocked: ${data['blocked'] ? 'Yes' : 'No'}'),
+                  Text('Flagged: ${data['flagged'] ? 'Yes' : 'No'}'),
+                  const SizedBox(height: 16),
+                  Text('Total Service Requests: ${data['totalRequests']}'),
+                  Text('Total Amount Spent: \$${(data['totalSpent'] as double).toStringAsFixed(2)}'),
+                  Text('Number of Paid Invoices: ${data['paidInvoices']}'),
+                  Text('Number of Overdue Invoices: ${data['overdueInvoices']}'),
+                  Text('Number of Pending Invoices: ${data['pendingInvoices']}'),
+                  Text('Highest Payment Made: \$${(data['highestPayment'] as double).toStringAsFixed(2)}'),
+                  const SizedBox(height: 16),
+                  const Text('Invoices', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                  const SizedBox(height: 8),
+                  ...invoices.map((doc) {
+                    final invoice = doc.data();
+                    final invoiceNum = invoice['invoiceNumber'] ?? doc.id;
+                    final mechanicId = invoice['mechanicId'];
+                    final paymentStatus = (invoice['paymentStatus'] ?? 'pending') as String;
+                    final statusField = invoice['status'];
+                    final Timestamp? createdAtTs = invoice['createdAt'];
+                    final bool overdue = paymentStatus == 'pending' &&
+                        createdAtTs != null &&
+                        DateTime.now().difference(createdAtTs.toDate()).inDays > 7;
+                    String status;
+                    if (statusField == 'closed') {
+                      status = 'closed';
+                    } else if (overdue) {
+                      status = 'overdue';
+                    } else if (paymentStatus == 'paid') {
+                      status = 'paid';
+                    } else {
+                      status = 'pending';
+                    }
+                    final price = (invoice['finalPrice'] as num?)?.toDouble();
+
+                    return Card(
+                      margin: const EdgeInsets.symmetric(vertical: 4),
+                      child: Padding(
+                        padding: const EdgeInsets.all(12),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                Text('Invoice #: $invoiceNum',
+                                    style: const TextStyle(fontWeight: FontWeight.bold)),
+                                Container(
+                                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                                  decoration: BoxDecoration(
+                                    color: _statusColor(status),
+                                    borderRadius: BorderRadius.circular(8),
+                                  ),
+                                  child: Text(
+                                    status,
+                                    style: const TextStyle(color: Colors.white),
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 4),
+                            FutureBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+                              future: mechanicId != null
+                                  ? FirebaseFirestore.instance
+                                      .collection('users')
+                                      .doc(mechanicId)
+                                      .get()
+                                  : Future.value(null),
+                              builder: (context, snap) {
+                                final name = snap.data?.data()?['username'] ?? 'Unknown';
+                                return Text('Mechanic: $name');
+                              },
+                            ),
+                            Text('Created: ${_formatDate(createdAtTs)}'),
+                            if (price != null) Text('Final Price: \$${price.toStringAsFixed(2)}'),
+                          ],
+                        ),
+                      ),
+                    );
+                  }).toList(),
+                ],
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -11,6 +11,7 @@ import 'admin_user_detail_page.dart';
 import 'admin_financial_report_page.dart';
 import 'admin_invoice_detail_page.dart';
 import 'admin_mechanic_performance_page.dart';
+import 'admin_customer_history_page.dart';
 
 /// Simple admin dashboard for monitoring the platform.
 class AdminDashboardPage extends StatefulWidget {
@@ -1188,6 +1189,21 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
               },
               tooltip: 'View Performance',
             ),
+          if (data['role'] == 'customer')
+            TextButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => AdminCustomerHistoryPage(
+                      customerId: doc.id,
+                      userId: widget.userId,
+                    ),
+                  ),
+                );
+              },
+              child: const Text('View History'),
+            ),
           _buildStatusBadges(data),
         ],
       ),
@@ -1612,6 +1628,20 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                       tooltip: 'View Details',
                     ),
                     TextButton(
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => AdminCustomerHistoryPage(
+                              customerId: d.id,
+                              userId: widget.userId,
+                            ),
+                          ),
+                        );
+                      },
+                      child: const Text('View History'),
+                    ),
+                    TextButton(
                       onPressed: () => _unblockCustomer(d.id),
                       child: const Text('Unblock Customer'),
                     ),
@@ -1686,6 +1716,20 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                       tooltip: 'View Details',
                     ),
                     TextButton(
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => AdminCustomerHistoryPage(
+                              customerId: d.id,
+                              userId: widget.userId,
+                            ),
+                          ),
+                        );
+                      },
+                      child: const Text('View History'),
+                    ),
+                    TextButton(
                       onPressed: flagged ? null : () => _flagCustomer(d.id),
                       child: const Text('Flag Customer'),
                     ),
@@ -1757,6 +1801,20 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                         );
                       },
                       tooltip: 'View Details',
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => AdminCustomerHistoryPage(
+                              customerId: d.id,
+                              userId: widget.userId,
+                            ),
+                          ),
+                        );
+                      },
+                      child: const Text('View History'),
                     ),
                     TextButton(
                       onPressed: () => _unflagCustomer(d.id),


### PR DESCRIPTION
## Summary
- create `AdminCustomerHistoryPage` for admins to view customer service history
- integrate new page with admin dashboard and add "View History" buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bd97e16ec832f86629e8f0000fa0a