### PR TITLE
Add color-coded payment status badges

### DIFF
--- a/lib/pages/customer_invoices_page.dart
+++ b/lib/pages/customer_invoices_page.dart
@@ -17,9 +17,9 @@ class CustomerInvoicesPage extends StatelessWidget {
       case 'overdue':
         return Colors.red;
       case 'closed':
-        return Colors.blueGrey;
+        return Colors.grey;
       default:
-        return Colors.orange;
+        return Colors.yellow;
     }
   }
 
@@ -108,16 +108,12 @@ class CustomerInvoicesPage extends StatelessWidget {
                               'Invoice #: $invoiceNum',
                               style: const TextStyle(fontWeight: FontWeight.bold),
                             ),
-                            Container(
-                              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                              decoration: BoxDecoration(
-                                color: _statusColor(status),
-                                borderRadius: BorderRadius.circular(8),
-                              ),
-                              child: Text(
-                                status,
+                            Chip(
+                              label: Text(
+                                status[0].toUpperCase() + status.substring(1),
                                 style: const TextStyle(color: Colors.white),
                               ),
+                              backgroundColor: _statusColor(status),
                             ),
                           ],
                         ),

--- a/lib/pages/mechanic_job_history_page.dart
+++ b/lib/pages/mechanic_job_history_page.dart
@@ -17,9 +17,9 @@ class MechanicJobHistoryPage extends StatelessWidget {
       case 'overdue':
         return Colors.red;
       case 'closed':
-        return Colors.blueGrey;
+        return Colors.grey;
       default:
-        return Colors.orange;
+        return Colors.yellow;
     }
   }
 
@@ -107,16 +107,12 @@ class MechanicJobHistoryPage extends StatelessWidget {
                               'Invoice #: $invoiceNum',
                               style: const TextStyle(fontWeight: FontWeight.bold),
                             ),
-                            Container(
-                              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                              decoration: BoxDecoration(
-                                color: _statusColor(status),
-                                borderRadius: BorderRadius.circular(8),
-                              ),
-                              child: Text(
-                                status,
+                            Chip(
+                              label: Text(
+                                status[0].toUpperCase() + status.substring(1),
                                 style: const TextStyle(color: Colors.white),
                               ),
+                              backgroundColor: _statusColor(status),
                             ),
                           ],
                         ),


### PR DESCRIPTION
## Summary
- show payment status with color-coded badges on invoice lists
- use consistent green/red/yellow/gray colors for statuses
- display status labels in title case

## Testing
- `n/a` (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_687be0194814832fb66f6f2fd0839d12