### PR TITLE
Implement Any Tech broadcast

### DIFF
--- a/lib/pages/create_invoice_page.dart
+++ b/lib/pages/create_invoice_page.dart
@@ -209,7 +209,7 @@ class _CreateInvoicePageState extends State<CreateInvoicePage> {
       final userEmail = FirebaseAuth.instance.currentUser?.email ?? '';
 
       await FirebaseFirestore.instance.collection('invoices').add({
-        'mechanicId': widget.mechanicId,
+        'mechanicId': isAnyTech ? null : widget.mechanicId,
         'customerId': widget.customerId,
         'invoiceNumber': invoiceNumber,
         'mechanicUsername': widget.mechanicUsername,


### PR DESCRIPTION
## Summary
- broadcast Any Tech service requests to all active mechanics
- add `mechanicId` null handling and candidate update in cloud function
- save invoices with null `mechanicId` when Any Tech is chosen
- allow mechanics to accept unclaimed requests

## Testing
- `node -c functions/index.js`

------
https://chatgpt.com/codex/tasks/task_e_687c02585cd0832f86b4446f5b1948e1