### PR TITLE
Add customer notification center

### DIFF
--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -12,6 +12,7 @@ import 'messages_page.dart';
 import 'customer_invoices_page.dart';
 import 'customer_service_history_page.dart';
 import 'customer_profile_page.dart';
+import 'customer_notifications_page.dart';
 
 class CustomerDashboard extends StatefulWidget {
   final String userId;
@@ -536,11 +537,28 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
     );
   }
 
+  void _openNotifications() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => CustomerNotificationsPage(userId: widget.userId),
+      ),
+    );
+  }
+
   Widget _buildMessagesIcon() {
     return IconButton(
       icon: const Icon(Icons.mail),
       tooltip: 'Messages',
       onPressed: _openMessages,
+    );
+  }
+
+  Widget _buildNotificationsIcon() {
+    return IconButton(
+      icon: const Icon(Icons.notifications),
+      tooltip: 'Notifications',
+      onPressed: _openNotifications,
     );
   }
 
@@ -893,6 +911,7 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
             ),
           ),
           _buildMessagesIcon(),
+          _buildNotificationsIcon(),
         ],
       ),
       body: !_locationPermissionGranted

--- a/lib/pages/customer_notifications_page.dart
+++ b/lib/pages/customer_notifications_page.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:intl/intl.dart';
+
+/// Page that displays notifications for a customer.
+class CustomerNotificationsPage extends StatelessWidget {
+  final String userId;
+
+  const CustomerNotificationsPage({super.key, required this.userId});
+
+  String _formatDate(Timestamp? ts) {
+    if (ts == null) return '';
+    final dt = ts.toDate().toLocal();
+    return DateFormat('MM/dd h:mm a').format(dt);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final stream = FirebaseFirestore.instance
+        .collection('notifications')
+        .doc(userId)
+        .collection('messages')
+        .orderBy('timestamp', descending: true)
+        .snapshots();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Notifications')),
+      body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+        stream: stream,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          final docs = snapshot.data?.docs ?? [];
+          if (docs.isEmpty) {
+            return const Center(child: Text('No notifications'));
+          }
+
+          return ListView.builder(
+            itemCount: docs.length,
+            itemBuilder: (context, index) {
+              final doc = docs[index];
+              final data = doc.data();
+              final title = data['title'] ?? '';
+              final body = data['body'] ?? '';
+              final Timestamp? ts = data['timestamp'];
+              final bool read = data['read'] == true;
+              return ListTile(
+                title: Text(
+                  title,
+                  style: TextStyle(
+                    fontWeight: read ? FontWeight.normal : FontWeight.bold,
+                  ),
+                ),
+                subtitle: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (body.isNotEmpty) Text(body),
+                    Text(_formatDate(ts)),
+                  ],
+                ),
+                onTap: () {
+                  if (!read) {
+                    FirebaseFirestore.instance
+                        .collection('notifications')
+                        .doc(userId)
+                        .collection('messages')
+                        .doc(doc.id)
+                        .update({'read': true});
+                  }
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a `CustomerNotificationsPage` for viewing notifications
- link the new page from `CustomerDashboard`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c0514b85c832fbdca11bcae3296e5