### PR TITLE
Add mechanic notifications page

### DIFF
--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -13,6 +13,7 @@ import 'mechanic_requests_page.dart';
 import 'mechanic_job_history_page.dart';
 import 'mechanic_profile_page.dart';
 import 'mechanic_earnings_report_page.dart';
+import 'mechanic_notifications_page.dart';
 
 BitmapDescriptor? wrenchIcon;
 
@@ -470,11 +471,28 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
     );
   }
 
+  void _openNotifications() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => MechanicNotificationsPage(userId: widget.userId),
+      ),
+    );
+  }
+
   Widget _buildMessagesIcon() {
     return IconButton(
       icon: const Icon(Icons.mail),
       tooltip: 'Messages',
       onPressed: _openMessages,
+    );
+  }
+
+  Widget _buildNotificationsIcon() {
+    return IconButton(
+      icon: const Icon(Icons.notifications),
+      tooltip: 'Notifications',
+      onPressed: _openNotifications,
     );
   }
 
@@ -583,6 +601,7 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
             ),
           ),
           _buildMessagesIcon(),
+          _buildNotificationsIcon(),
         ],
       ),
       body: _blocked

--- a/lib/pages/mechanic_notifications_page.dart
+++ b/lib/pages/mechanic_notifications_page.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:intl/intl.dart';
+
+/// Page that displays notifications for a mechanic.
+class MechanicNotificationsPage extends StatelessWidget {
+  final String userId;
+
+  const MechanicNotificationsPage({super.key, required this.userId});
+
+  String _formatDate(Timestamp? ts) {
+    if (ts == null) return '';
+    final dt = ts.toDate().toLocal();
+    return DateFormat('MM/dd h:mm a').format(dt);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final stream = FirebaseFirestore.instance
+        .collection('notifications')
+        .doc(userId)
+        .collection('messages')
+        .orderBy('timestamp', descending: true)
+        .snapshots();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Notifications')),
+      body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+        stream: stream,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          final docs = snapshot.data?.docs ?? [];
+          if (docs.isEmpty) {
+            return const Center(child: Text('No notifications'));
+          }
+
+          return ListView.builder(
+            itemCount: docs.length,
+            itemBuilder: (context, index) {
+              final doc = docs[index];
+              final data = doc.data();
+              final title = data['title'] ?? '';
+              final body = data['body'] ?? '';
+              final Timestamp? ts = data['timestamp'];
+              final bool read = data['read'] == true;
+              return ListTile(
+                title: Text(
+                  title,
+                  style: TextStyle(
+                    fontWeight: read ? FontWeight.normal : FontWeight.bold,
+                  ),
+                ),
+                subtitle: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (body.isNotEmpty) Text(body),
+                    Text(_formatDate(ts)),
+                  ],
+                ),
+                onTap: () {
+                  if (!read) {
+                    FirebaseFirestore.instance
+                        .collection('notifications')
+                        .doc(userId)
+                        .collection('messages')
+                        .doc(doc.id)
+                        .update({'read': true});
+                  }
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new `MechanicNotificationsPage` to display mechanic notifications
- open notifications page from mechanic dashboard via new icon button

## Testing
- `dart` unavailable so formatting skipped


------
https://chatgpt.com/codex/tasks/task_e_687c07a7453c832f835fc46afdbda060