### PR TITLE
Add broadcast request response tracking

### DIFF
--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -311,10 +311,12 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
 
         final currentUid = FirebaseAuth.instance.currentUser?.uid;
         final List<dynamic>? candidates = data['mechanicCandidates'] as List<dynamic>?;
+        final List<dynamic>? responded = data['mechanicResponded'] as List<dynamic>?;
         final bool canAccept = widget.role == 'mechanic' &&
             data['mechanicId'] == null &&
             currentUid != null &&
-            (candidates?.contains(currentUid) ?? false);
+            (candidates?.contains(currentUid) ?? false) &&
+            !(responded?.contains(currentUid) ?? false);
 
         if (canAccept) {
           children.add(


### PR DESCRIPTION
## Summary
- store `mechanicResponded` array when broadcasting invoices
- notify customer when all mechanics decline
- filter mechanic inbox using `mechanicResponded`
- disable accepting/allow declining for broadcast requests
- block accept button after mechanic declined

## Testing
- `node --check functions/index.js`

------
https://chatgpt.com/codex/tasks/task_e_687c094ed4bc832fb9ca839a1c0e647f