### PR TITLE
Add maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ firebase_options.dart
 - text
 - timestamp
 
+### system/config
+- maintenanceMode: `true` or `false`
+- maintenanceMessage: string
+
 ## Setup Instructions
 
 1. Clone the repository.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'pages/dashboard_page.dart';
 import 'pages/mechanic_request_queue_page.dart';
 import 'pages/customer_invoices_page.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'pages/maintenance_mode_page.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -63,12 +64,33 @@ class _MyAppState extends State<MyApp> {
   late StreamSubscription<User?> _authSub;
   String? _currentUserId;
   bool _loading = true;
+  StreamSubscription<DocumentSnapshot<Map<String, dynamic>>>? _maintSub;
+  bool? _maintenanceMode;
+  String _maintenanceMessage = '';
 
   @override
   void initState() {
     super.initState();
     _pushService.listenToForegroundMessages();
+    _listenMaintenance();
     _initAuth();
+  }
+
+  void _listenMaintenance() {
+    _maintSub = FirebaseFirestore.instance
+        .collection('system')
+        .doc('config')
+        .snapshots()
+        .listen((snap) {
+      final data = snap.data();
+      if (data != null) {
+        setState(() {
+          _maintenanceMode = data['maintenanceMode'] == true;
+          _maintenanceMessage =
+              (data['maintenanceMessage'] ?? '').toString();
+        });
+      }
+    });
   }
 
   Future<void> _initAuth() async {
@@ -107,17 +129,27 @@ class _MyAppState extends State<MyApp> {
   @override
   void dispose() {
     _authSub.cancel();
+    _maintSub?.cancel();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    if (_loading) {
+    if (_loading || _maintenanceMode == null) {
       return MaterialApp(
         navigatorKey: navigatorKey,
         home: const Scaffold(
           body: Center(child: CircularProgressIndicator()),
         ),
+      );
+    }
+    if (_maintenanceMode == true) {
+      return MaterialApp(
+        navigatorKey: navigatorKey,
+        title: 'SkipTow',
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange)),
+        home: MaintenanceModePage(message: _maintenanceMessage),
       );
     }
     return MaterialApp(

--- a/lib/pages/maintenance_mode_page.dart
+++ b/lib/pages/maintenance_mode_page.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class MaintenanceModePage extends StatelessWidget {
+  final String message;
+  const MaintenanceModePage({super.key, required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                '🚧 Maintenance Mode',
+                style: Theme.of(context).textTheme.headlineMedium,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 20),
+              Text(
+                message,
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- block app usage if maintenance mode is active
- add dedicated maintenance screen
- document the new Firestore `system/config` document

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c1010a2e0832f8988dcf612743387