### PR TITLE
Add customer request history page

### DIFF
--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -11,8 +11,8 @@ import '../services/alert_service.dart';
 import 'service_request_history_page.dart';
 import 'messages_page.dart';
 import 'customer_invoices_page.dart';
-import 'customer_service_history_page.dart';
 import 'customer_profile_page.dart';
+import 'customer_request_history_page.dart';
 import 'customer_notifications_page.dart';
 
 class CustomerDashboard extends StatefulWidget {
@@ -926,7 +926,7 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (_) => CustomerServiceHistoryPage(
+                  builder: (_) => CustomerRequestHistoryPage(
                     userId: widget.userId,
                   ),
                 ),


### PR DESCRIPTION
## Summary
- create `CustomerRequestHistoryPage` for viewing all service requests with filters
- link to new page from customer dashboard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c10a94918832fbc94bb164e2dcb03