### PR TITLE
Add radius change tracking

### DIFF
--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -14,6 +14,7 @@ import 'mechanic_job_history_page.dart';
 import 'mechanic_profile_page.dart';
 import 'mechanic_earnings_report_page.dart';
 import 'mechanic_notifications_page.dart';
+import 'mechanic_radius_history_page.dart';
 import '../services/alert_service.dart';
 
 BitmapDescriptor? wrenchIcon;
@@ -681,6 +682,19 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
               );
             },
           ),
+          IconButton(
+            icon: const Icon(Icons.timeline),
+            tooltip: 'Radius History',
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) =>
+                      MechanicRadiusHistoryPage(mechanicId: widget.userId),
+                ),
+              );
+            },
+          ),
           TextButton.icon(
             onPressed: () {
               Navigator.push(
@@ -909,12 +923,23 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                         if (mounted) {
                           ScaffoldMessenger.of(context).showSnackBar(
                             const SnackBar(
-                                content: Text(
-                                    'An error occurred. Please try again.')),
+                                content: Text('An error occurred. Please try again.')),
                           );
                         }
                         debugPrint('$e');
                       }
+                    }
+                    try {
+                      await FirebaseFirestore.instance
+                          .collection('mechanics')
+                          .doc(widget.userId)
+                          .collection('radius_history')
+                          .add({
+                        'timestamp': DateTime.now(),
+                        'newRadiusMiles': val,
+                      });
+                    } catch (e) {
+                      logError('Radius history log error: $e');
                     }
                   },
                 ),

--- a/lib/pages/mechanic_radius_history_page.dart
+++ b/lib/pages/mechanic_radius_history_page.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:intl/intl.dart';
+
+/// Displays the history of radius changes for a mechanic.
+class MechanicRadiusHistoryPage extends StatelessWidget {
+  final String mechanicId;
+
+  const MechanicRadiusHistoryPage({super.key, required this.mechanicId});
+
+  String _formatDate(Timestamp? ts) {
+    if (ts == null) return '';
+    final dt = ts.toDate().toLocal();
+    return DateFormat('MMMM d, yyyy h:mm a').format(dt);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final stream = FirebaseFirestore.instance
+        .collection('mechanics')
+        .doc(mechanicId)
+        .collection('radius_history')
+        .orderBy('timestamp', descending: true)
+        .snapshots();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Radius History')),
+      body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+        stream: stream,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          final docs = snapshot.data?.docs ?? [];
+          if (docs.isEmpty) {
+            return const Center(child: Text('No radius changes found'));
+          }
+
+          return ListView.builder(
+            itemCount: docs.length,
+            itemBuilder: (context, index) {
+              final data = docs[index].data();
+              final radius = (data['newRadiusMiles'] as num?)?.toDouble() ?? 0.0;
+              final ts = data['timestamp'] as Timestamp?;
+              return ListTile(
+                leading: const Icon(Icons.radio_button_checked),
+                title: Text('Radius: ${radius.toStringAsFixed(0)} miles'),
+                subtitle: Text(_formatDate(ts)),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- log mechanic radius changes to a new `radius_history` subcollection
- create `MechanicRadiusHistoryPage` to view changes
- link to radius history from the mechanic dashboard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c152b8e50832fb4e693118112264f