### PR TITLE
Implement admin request reassignment

### DIFF
--- a/lib/pages/admin_invoice_detail_page.dart
+++ b/lib/pages/admin_invoice_detail_page.dart
@@ -23,11 +23,14 @@ class AdminInvoiceDetailPage extends StatefulWidget {
 
 class _AdminInvoiceDetailPageState extends State<AdminInvoiceDetailPage> {
   late Future<Map<String, dynamic>?> _invoiceFuture;
+  late Future<List<Map<String, String>>> _mechanicsFuture;
+  String? _selectedMechanicId;
 
   @override
   void initState() {
     super.initState();
     _invoiceFuture = _loadInvoice();
+    _mechanicsFuture = _loadMechanics();
   }
 
   Future<String?> _getRole() async {
@@ -61,6 +64,20 @@ class _AdminInvoiceDetailPageState extends State<AdminInvoiceDetailPage> {
     }
 
     return data;
+  }
+
+  Future<List<Map<String, String>>> _loadMechanics() async {
+    final snap = await FirebaseFirestore.instance
+        .collection('users')
+        .where('role', isEqualTo: 'mechanic')
+        .where('isActive', isEqualTo: true)
+        .get();
+    return snap.docs
+        .map((d) => {
+              'id': d.id,
+              'username': d.data()['username'] ?? d.id,
+            })
+        .toList();
   }
 
   String _formatDate(Timestamp? ts) {
@@ -141,6 +158,75 @@ class _AdminInvoiceDetailPageState extends State<AdminInvoiceDetailPage> {
     );
   }
 
+  Future<void> _reassignRequest(
+      Map<String, dynamic> invoiceData, String mechanicId) async {
+    final invoiceRef = FirebaseFirestore.instance
+        .collection('invoices')
+        .doc(widget.invoiceId);
+
+    final mechDoc = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(mechanicId)
+        .get();
+    final newUsername = mechDoc.data()?['username'] ?? 'Mechanic';
+
+    await invoiceRef.update({
+      'mechanicId': mechanicId,
+      'mechanicUsername': newUsername,
+      'mechanicAccepted': false,
+      'status': 'active',
+      'reassignmentHistory': FieldValue.arrayUnion([
+        {
+          'mechanicId': mechanicId,
+          'timestamp': FieldValue.serverTimestamp(),
+        }
+      ])
+    });
+
+    final oldMech = invoiceData['mechanicId'];
+    final customerId = invoiceData['customerId'];
+
+    await FirebaseFirestore.instance.collection('admin_logs').add({
+      'action': 'reassignRequest',
+      'invoiceId': widget.invoiceId,
+      'oldMechanicId': oldMech,
+      'newMechanicId': mechanicId,
+      'timestamp': FieldValue.serverTimestamp(),
+    });
+
+    await FirebaseFirestore.instance
+        .collection('notifications')
+        .doc(mechanicId)
+        .collection('messages')
+        .add({
+      'title': 'New Service Request Assigned',
+      'body': 'A service request has been assigned to you.',
+      'timestamp': FieldValue.serverTimestamp(),
+    });
+
+    if (customerId != null) {
+      await FirebaseFirestore.instance
+          .collection('notifications')
+          .doc(customerId)
+          .collection('messages')
+          .add({
+        'title': 'Mechanic Reassigned',
+        'body': 'Your request has been reassigned to $newUsername.',
+        'timestamp': FieldValue.serverTimestamp(),
+      });
+    }
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Request reassigned.')),
+      );
+      setState(() {
+        _invoiceFuture = _loadInvoice();
+        _selectedMechanicId = null;
+      });
+    }
+  }
+
   Widget _buildDetails(Map<String, dynamic> data) {
     final car = data['carInfo'] ?? {};
     final carText =
@@ -180,6 +266,48 @@ class _AdminInvoiceDetailPageState extends State<AdminInvoiceDetailPage> {
               'Total Amount: \$${(data['finalPrice'] as num).toStringAsFixed(2)}'),
         Text('Customer: ${data['customerUsername'] ?? 'Unknown'}'),
         Text('Mechanic: ${data['mechanicUsername'] ?? 'Unknown'}'),
+        FutureBuilder<List<Map<String, String>>>(
+          future: _mechanicsFuture,
+          builder: (context, mechSnap) {
+            if (!mechSnap.hasData) return const SizedBox.shrink();
+            final mechanics = mechSnap.data!;
+            final isComplete =
+                data['status'] == 'completed' || data['status'] == 'closed';
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                DropdownButtonFormField<String>(
+                  value: _selectedMechanicId ?? data['mechanicId'],
+                  decoration:
+                      const InputDecoration(labelText: 'Select Mechanic'),
+                  items: mechanics
+                      .map(
+                        (m) => DropdownMenuItem(
+                          value: m['id'],
+                          child: Text(m['username'] ?? m['id']),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: isComplete
+                      ? null
+                      : (val) {
+                          setState(() {
+                            _selectedMechanicId = val;
+                          });
+                        },
+                ),
+                const SizedBox(height: 8),
+                ElevatedButton(
+                  onPressed: isComplete || _selectedMechanicId == null
+                      ? null
+                      : () => _reassignRequest(
+                          data, _selectedMechanicId!),
+                  child: const Text('Reassign Request'),
+                ),
+              ],
+            );
+          },
+        ),
         if (carText.isNotEmpty) Text('Car: $carText'),
         if ((data['description'] ?? '').toString().isNotEmpty)
           Text('Service: ${data['description']}'),


### PR DESCRIPTION
## Summary
- allow admins to reassign a mechanic on the invoice detail page
- log reassignment and notify new mechanic and customer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c221997c0832f95bc2f3539d43a4e