### PR TITLE
Implement suspicious account flag

### DIFF
--- a/lib/pages/admin_customer_history_page.dart
+++ b/lib/pages/admin_customer_history_page.dart
@@ -235,6 +235,7 @@ class _AdminCustomerHistoryPageState extends State<AdminCustomerHistoryPage> {
                   Text('Registration Date: ${_formatDate(data['createdAt'] as Timestamp?)}'),
                   Text('Blocked: ${data['blocked'] ? 'Yes' : 'No'}'),
                   Text('Flagged: ${data['flagged'] ? 'Yes' : 'No'}'),
+                  Text('Suspicious: ${data['suspicious'] ? 'Yes' : 'No'}'),
                   const SizedBox(height: 16),
                   Text('Total Service Requests: ${data['totalRequests']}'),
                   Text('Total Amount Spent: \$${(data['totalSpent'] as double).toStringAsFixed(2)}'),

--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -43,6 +43,9 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
   int _flaggedCustomers = 0;
   int _flaggedUsers = 0;
   int _blockedUsers = 0;
+  int _suspiciousMechanics = 0;
+  int _suspiciousCustomers = 0;
+  int _suspiciousUsers = 0;
   int _totalActiveUsers = 0;
   int _newCustomers = 0;
   int _newMechanics = 0;
@@ -89,6 +92,8 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
   StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _newMechanicsSub;
   StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _flaggedCustomersSub;
   StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _flaggedMechanicsSub;
+  StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _suspiciousCustomersSub;
+  StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _suspiciousMechanicsSub;
 
   late Stream<QuerySnapshot<Map<String, dynamic>>> _invoiceStream;
   String _invoiceStatusFilter = 'all';
@@ -186,6 +191,40 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
         _flaggedUsers = _flaggedCustomers + _flaggedMechanics;
       }
     });
+
+    _suspiciousCustomersSub = FirebaseFirestore.instance
+        .collection('users')
+        .where('role', isEqualTo: 'customer')
+        .where('suspicious', isEqualTo: true)
+        .snapshots()
+        .listen((snapshot) {
+      if (mounted) {
+        setState(() {
+          _suspiciousCustomers = snapshot.size;
+          _suspiciousUsers = _suspiciousCustomers + _suspiciousMechanics;
+        });
+      } else {
+        _suspiciousCustomers = snapshot.size;
+        _suspiciousUsers = _suspiciousCustomers + _suspiciousMechanics;
+      }
+    });
+
+    _suspiciousMechanicsSub = FirebaseFirestore.instance
+        .collection('users')
+        .where('role', isEqualTo: 'mechanic')
+        .where('suspicious', isEqualTo: true)
+        .snapshots()
+        .listen((snapshot) {
+      if (mounted) {
+        setState(() {
+          _suspiciousMechanics = snapshot.size;
+          _suspiciousUsers = _suspiciousCustomers + _suspiciousMechanics;
+        });
+      } else {
+        _suspiciousMechanics = snapshot.size;
+        _suspiciousUsers = _suspiciousCustomers + _suspiciousMechanics;
+      }
+    });
     _loadStats();
     _loadAppVersion();
   }
@@ -250,6 +289,15 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
             d.data()['role'] == 'customer' && d.data()['flagged'] == true)
         .length;
     _flaggedUsers = _flaggedMechanics + _flaggedCustomers;
+    _suspiciousMechanics = usersSnapshot.docs
+        .where((d) =>
+            d.data()['role'] == 'mechanic' && d.data()['suspicious'] == true)
+        .length;
+    _suspiciousCustomers = usersSnapshot.docs
+        .where((d) =>
+            d.data()['role'] == 'customer' && d.data()['suspicious'] == true)
+        .length;
+    _suspiciousUsers = _suspiciousMechanics + _suspiciousCustomers;
 
     final activeSnap = await FirebaseFirestore.instance
         .collection('invoices')
@@ -503,6 +551,8 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
     int blockedCustomerCount = 0;
     int flaggedCount = 0;
     int flaggedCustomerCount = 0;
+    int suspiciousCount = 0;
+    int suspiciousCustomerCount = 0;
     int customerCount = 0;
     int mechanicCount = 0;
     final Map<String, String> nameMap = {};
@@ -519,11 +569,13 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
         }
         if (data['blocked'] == true) blockedCount++;
         if (data['flagged'] == true) flaggedCount++;
+        if (data['suspicious'] == true) suspiciousCount++;
       } else if (role == 'customer') {
         customerCount++;
         count++;
         if (data['blocked'] == true) blockedCustomerCount++;
         if (data['flagged'] == true) flaggedCustomerCount++;
+        if (data['suspicious'] == true) suspiciousCustomerCount++;
         final Timestamp? ts = data['createdAt'];
         if (ts != null) {
           final dt = ts.toDate();
@@ -536,6 +588,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
     }
     final totalBlocked = blockedCount + blockedCustomerCount;
     final totalFlagged = flaggedCount + flaggedCustomerCount;
+    final totalSuspicious = suspiciousCount + suspiciousCustomerCount;
     if (!mounted) {
       _totalActiveUsers = count;
       _activeMechanics = mechCount;
@@ -547,6 +600,9 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
       _flaggedMechanics = flaggedCount;
       _flaggedCustomers = flaggedCustomerCount;
       _flaggedUsers = totalFlagged;
+      _suspiciousMechanics = suspiciousCount;
+      _suspiciousCustomers = suspiciousCustomerCount;
+      _suspiciousUsers = totalSuspicious;
       _totalCustomers = customerCount;
       _totalMechanics = mechanicCount;
       return;
@@ -562,6 +618,9 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
       _flaggedMechanics = flaggedCount;
       _flaggedCustomers = flaggedCustomerCount;
       _flaggedUsers = totalFlagged;
+      _suspiciousMechanics = suspiciousCount;
+      _suspiciousCustomers = suspiciousCustomerCount;
+      _suspiciousUsers = totalSuspicious;
       _totalCustomers = customerCount;
       _totalMechanics = mechanicCount;
     });
@@ -719,6 +778,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
         _summaryCard('Total Mechanics', '$_totalMechanics', Colors.blue),
         _summaryCard('Blocked Accounts', '$_blockedUsers', Colors.red),
         _summaryCard('Flagged Accounts', '$_flaggedUsers', Colors.orange),
+        _summaryCard('Suspicious Accounts', '$_suspiciousUsers', Colors.red),
         _summaryCard('Active Mechanics', '$_activeMechanics', Colors.green),
         _summaryCard('Overdue Invoices', '$_overdueInvoices', Colors.red),
         _summaryCard('Outstanding Balance',
@@ -740,6 +800,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
         Text('Blocked Customers: $_blockedCustomers'),
         Text('Blocked Accounts: $_blockedUsers'),
         Text('Flagged Accounts: $_flaggedUsers'),
+        Text('Suspicious Accounts: $_suspiciousUsers'),
         Text('Flagged Mechanics: $_flaggedMechanics'),
         Text('Flagged Customers: $_flaggedCustomers'),
         Text('Total Active Users: $_totalActiveUsers'),
@@ -852,6 +913,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
   Widget _buildStatusBadges(Map<String, dynamic> data) {
     final blocked = data['blocked'] == true;
     final flagged = data['flagged'] == true;
+    final suspicious = data['suspicious'] == true;
     final List<Widget> badges = [];
     if (blocked) {
       badges.add(
@@ -872,6 +934,17 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
             style: TextStyle(color: Colors.black, fontSize: 12),
           ),
           backgroundColor: Colors.yellow,
+        ),
+      );
+    }
+    if (suspicious) {
+      badges.add(
+        const Chip(
+          label: Text(
+            'Suspicious',
+            style: TextStyle(color: Colors.white, fontSize: 12),
+          ),
+          backgroundColor: Colors.red,
         ),
       );
     }
@@ -1236,6 +1309,10 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
           docs = docs
               .where((d) => d.data()['flagged'] == true && d.data()['blocked'] != true)
               .toList();
+        } else if (_accountStatusFilter == 'suspicious') {
+          docs = docs
+              .where((d) => d.data()['suspicious'] == true && d.data()['blocked'] != true)
+              .toList();
         } else if (_accountStatusFilter == 'normal') {
           docs = docs
               .where((d) => d.data()['flagged'] != true && d.data()['blocked'] != true)
@@ -1244,8 +1321,9 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
 
         int rank(Map<String, dynamic> data) {
           if (data['blocked'] == true) return 0;
-          if (data['flagged'] == true) return 1;
-          return 2;
+          if (data['suspicious'] == true) return 1;
+          if (data['flagged'] == true) return 2;
+          return 3;
         }
 
         docs.sort((a, b) => rank(a.data()).compareTo(rank(b.data())));
@@ -1274,7 +1352,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
     final snapshot = await FirebaseFirestore.instance.collection('users').get();
     final buffer = StringBuffer();
     buffer.writeln(
-        'Username,Email,Role,User ID,Created Date,Blocked,Flagged');
+        'Username,Email,Role,User ID,Created Date,Blocked,Flagged,Suspicious');
     for (final doc in snapshot.docs) {
       final data = doc.data();
       final username =
@@ -1284,6 +1362,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
       final created = _formatDate(data['createdAt'] as Timestamp?);
       final blocked = data['blocked'] == true ? 'yes' : 'no';
       final flagged = data['flagged'] == true ? 'yes' : 'no';
+      final suspicious = data['suspicious'] == true ? 'yes' : 'no';
       final row = [
         username,
         email,
@@ -1292,6 +1371,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
         created,
         blocked,
         flagged,
+        suspicious,
       ].map(_csvEscape).join(',');
       buffer.writeln(row);
     }
@@ -1841,6 +1921,8 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
     _newMechanicsSub?.cancel();
     _flaggedCustomersSub?.cancel();
     _flaggedMechanicsSub?.cancel();
+    _suspiciousCustomersSub?.cancel();
+    _suspiciousMechanicsSub?.cancel();
     _invoiceNumberController.dispose();
     _customerUsernameController.dispose();
     _mechanicUsernameController.dispose();
@@ -2127,6 +2209,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                           DropdownMenuItem(value: 'all', child: Text('All')),
                           DropdownMenuItem(value: 'blocked', child: Text('Blocked')),
                           DropdownMenuItem(value: 'flagged', child: Text('Flagged')),
+                          DropdownMenuItem(value: 'suspicious', child: Text('Suspicious')),
                           DropdownMenuItem(value: 'normal', child: Text('Normal')),
                         ],
                         onChanged: (value) {

--- a/lib/pages/admin_mechanic_performance_page.dart
+++ b/lib/pages/admin_mechanic_performance_page.dart
@@ -255,6 +255,7 @@ class _AdminMechanicPerformancePageState extends State<AdminMechanicPerformanceP
                   Text('Registration Date: ${_formatDate(data['createdAt'] as Timestamp?)}'),
                   Text('Blocked: ${data['blocked'] ? 'Yes' : 'No'}'),
                   Text('Flagged: ${data['flagged'] ? 'Yes' : 'No'}'),
+                  Text('Suspicious: ${data['suspicious'] ? 'Yes' : 'No'}'),
                   const SizedBox(height: 16),
                   _statItem('Total Jobs Completed', '${data['totalJobs']}'),
                   _statItem('Total Earnings Paid Out', _currency(data['totalEarnings'] as double)),

--- a/lib/pages/admin_user_detail_page.dart
+++ b/lib/pages/admin_user_detail_page.dart
@@ -16,6 +16,7 @@ class _AdminUserDetailPageState extends State<AdminUserDetailPage> {
   late Future<Map<String, dynamic>> _detailsFuture;
   bool _isBlocked = false;
   bool _isFlagged = false;
+  bool _isSuspicious = false;
 
   @override
   void initState() {
@@ -33,6 +34,7 @@ class _AdminUserDetailPageState extends State<AdminUserDetailPage> {
     setState(() {
       _isBlocked = userData['blocked'] == true;
       _isFlagged = userData['flagged'] == true;
+      _isSuspicious = userData['suspicious'] == true;
     });
 
     int completedJobs = 0;
@@ -78,6 +80,7 @@ class _AdminUserDetailPageState extends State<AdminUserDetailPage> {
       'role': role,
       'blocked': userData['blocked'] == true,
       'flagged': userData['flagged'] == true,
+      'suspicious': userData['suspicious'] == true,
       'completedJobs': completedJobs,
       'totalEarnings': totalEarnings,
       'totalRequests': totalRequests,
@@ -111,6 +114,18 @@ class _AdminUserDetailPageState extends State<AdminUserDetailPage> {
         .update({'flagged': newStatus});
     setState(() {
       _isFlagged = newStatus;
+      _detailsFuture = _loadDetails();
+    });
+  }
+
+  Future<void> _toggleSuspicious() async {
+    final newStatus = !_isSuspicious;
+    await FirebaseFirestore.instance
+        .collection('users')
+        .doc(widget.userId)
+        .update({'suspicious': newStatus});
+    setState(() {
+      _isSuspicious = newStatus;
       _detailsFuture = _loadDetails();
     });
   }
@@ -172,6 +187,25 @@ class _AdminUserDetailPageState extends State<AdminUserDetailPage> {
             children.add(const SizedBox(height: 8));
           }
 
+          if (_isSuspicious) {
+            children.add(
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(8),
+                color: Colors.red,
+                child: const Text(
+                  'SUSPICIOUS ACCOUNT',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+            children.add(const SizedBox(height: 8));
+          }
+
           children.addAll([
             Text('Username: ${data['username']}'),
             Text('User ID: ${widget.userId}'),
@@ -180,6 +214,7 @@ class _AdminUserDetailPageState extends State<AdminUserDetailPage> {
             Text('Account Created: ${_formatDate(data['createdAt'] as Timestamp?)}'),
             Text('Blocked: ${data['blocked'] == true ? 'Yes' : 'No'}'),
             Text('Flagged: ${data['flagged'] == true ? 'Yes' : 'No'}'),
+            Text('Suspicious: ${data['suspicious'] == true ? 'Yes' : 'No'}'),
             const SizedBox(height: 10),
             ElevatedButton(
               onPressed: _toggleBlock,
@@ -189,6 +224,12 @@ class _AdminUserDetailPageState extends State<AdminUserDetailPage> {
             ElevatedButton(
               onPressed: _toggleFlag,
               child: Text(_isFlagged ? 'Remove Flag' : 'Flag Account'),
+            ),
+            const SizedBox(height: 10),
+            ElevatedButton(
+              onPressed: _toggleSuspicious,
+              child:
+                  Text(_isSuspicious ? 'Unmark Suspicious' : 'Mark as Suspicious Account'),
             ),
             const SizedBox(height: 20),
           ];


### PR DESCRIPTION
## Summary
- allow admins to mark users as suspicious
- show a red `SUSPICIOUS ACCOUNT` banner on user detail view
- display suspicious badges across admin dashboards
- filter/sort users by suspicious status
- export suspicious status in user CSV

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c2285cfc8832fa08be3455c16ce2f