### PR TITLE
Prevent editing closed invoices

### DIFF
--- a/lib/pages/customer_request_history_page.dart
+++ b/lib/pages/customer_request_history_page.dart
@@ -237,7 +237,8 @@ class _CustomerRequestHistoryPageState extends State<CustomerRequestHistoryPage>
                             ),
                             if ((data['mechanicId'] == null ||
                                     data['mechanicAccepted'] != true) &&
-                                data['invoiceStatus'] != 'cancelled')
+                                data['invoiceStatus'] != 'cancelled' &&
+                                data['invoiceStatus'] != 'closed')
                               Align(
                                 alignment: Alignment.centerRight,
                                 child: TextButton(

--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -296,6 +296,10 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
     }
 
     final mechanicId = data['mechanicId'];
+    final String invoiceState =
+        (data['invoiceStatus'] ?? data['status'] ?? 'active').toString();
+    final bool chatDisabled =
+        invoiceState == 'closed' || invoiceState == 'cancelled';
     final stream = FirebaseFirestore.instance
         .collection('invoices')
         .doc(widget.invoiceId)
@@ -373,42 +377,43 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
               },
             ),
           ),
-          SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.all(8),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: TextField(
-                      controller: _messageController,
-                      decoration: const InputDecoration(
-                        hintText: 'Type a message',
-                        border: OutlineInputBorder(),
+          if (!chatDisabled)
+            SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.all(8),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: TextField(
+                        controller: _messageController,
+                        decoration: const InputDecoration(
+                          hintText: 'Type a message',
+                          border: OutlineInputBorder(),
+                        ),
                       ),
                     ),
-                  ),
-                  const SizedBox(width: 8),
-                  IconButton(
-                    icon: const Icon(Icons.photo),
-                    onPressed: _pickImage,
-                  ),
-                  if (_selectedImage != null)
-                    Padding(
-                      padding: const EdgeInsets.only(right: 8.0),
-                      child: SizedBox(
-                        height: 40,
-                        width: 40,
-                        child: Image.file(_selectedImage!),
-                      ),
+                    const SizedBox(width: 8),
+                    IconButton(
+                      icon: const Icon(Icons.photo),
+                      onPressed: _pickImage,
                     ),
-                  IconButton(
-                    icon: const Icon(Icons.send),
-                    onPressed: _sendChatMessage,
-                  ),
-                ],
+                    if (_selectedImage != null)
+                      Padding(
+                        padding: const EdgeInsets.only(right: 8.0),
+                        child: SizedBox(
+                          height: 40,
+                          width: 40,
+                          child: Image.file(_selectedImage!),
+                        ),
+                      ),
+                    IconButton(
+                      icon: const Icon(Icons.send),
+                      onPressed: _sendChatMessage,
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
         ],
       ),
     );
@@ -650,7 +655,10 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
                 : const Text('No customer review provided.'),
         ]);
 
-        if (widget.role == 'mechanic' && (status == 'accepted' || status == 'arrived' || status == 'in_progress')) {
+        if (widget.role == 'mechanic' &&
+            invoiceStatus != 'closed' &&
+            invoiceStatus != 'cancelled' &&
+            (status == 'accepted' || status == 'arrived' || status == 'in_progress')) {
           children.add(
             Padding(
               padding: const EdgeInsets.only(top: 8.0),
@@ -692,7 +700,9 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
             data['mechanicId'] == null &&
             currentUid != null &&
             (candidates?.contains(currentUid) ?? false) &&
-            !(responded?.contains(currentUid) ?? false);
+            !(responded?.contains(currentUid) ?? false) &&
+            invoiceStatus != 'closed' &&
+            invoiceStatus != 'cancelled';
 
         if (canAccept) {
           children.add(
@@ -741,7 +751,10 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
           );
         }
 
-        if (widget.role == 'mechanic' && status == 'accepted') {
+        if (widget.role == 'mechanic' &&
+            invoiceStatus != 'closed' &&
+            invoiceStatus != 'cancelled' &&
+            status == 'accepted') {
           children.add(
             Align(
               alignment: Alignment.centerRight,
@@ -764,7 +777,10 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
           );
         }
 
-        if (widget.role == 'mechanic' && status == 'arrived') {
+        if (widget.role == 'mechanic' &&
+            invoiceStatus != 'closed' &&
+            invoiceStatus != 'cancelled' &&
+            status == 'arrived') {
           children.add(
             Align(
               alignment: Alignment.centerRight,
@@ -788,6 +804,8 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
         }
 
         if (widget.role == 'mechanic' &&
+            invoiceStatus != 'closed' &&
+            invoiceStatus != 'cancelled' &&
             (status == 'active' ||
                 status == 'accepted' ||
                 status == 'arrived' ||

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -1390,9 +1390,11 @@ class _ActiveRequestCard extends StatelessWidget {
     final description = data['description'] ?? '';
     final location = data['location'];
     final status = (data['status'] ?? 'active').toString();
+    final invoiceStatus =
+        (data['invoiceStatus'] ?? data['status'] ?? 'active').toString();
 
     final actions = <Widget>[];
-    if (status != 'completed' && status != 'closed' && status != 'cancelled') {
+    if (invoiceStatus != 'closed' && invoiceStatus != 'cancelled') {
       actions.add(
         ElevatedButton(
           onPressed: () => _markCompleted(context),


### PR DESCRIPTION
## Summary
- disallow mechanic actions for closed or cancelled invoices
- hide customer cancel option once invoice finalized
- disable chat input when invoice is closed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cc2f261b8832f8ec21cb746471d45