### PR TITLE
Add closedAt timestamp when invoices finalize

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -1087,8 +1087,13 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                     'Created: ${_formatPrettyDate(createdAtTs)}',
                     style: Theme.of(context).textTheme.bodySmall,
                   ),
+                if (data['closedAt'] != null)
+                  Text(
+                    'Closed: ${_formatPrettyDate(data['closedAt'] as Timestamp?)}',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
                 if (finalPrice != null)
-                  Text('Total: $' + finalPrice.toStringAsFixed(2)),
+                  Text('Total: \$' + finalPrice.toStringAsFixed(2)),
               ],
             ),
             Text('Status: $status'),

--- a/lib/pages/admin_invoice_detail_page.dart
+++ b/lib/pages/admin_invoice_detail_page.dart
@@ -249,13 +249,17 @@ class _AdminInvoiceDetailPageState extends State<AdminInvoiceDetailPage> {
     );
     if (confirm != true) return;
 
-    await FirebaseFirestore.instance
-        .collection('invoices')
-        .doc(widget.invoiceId)
-        .update({
+    final docRef =
+        FirebaseFirestore.instance.collection('invoices').doc(widget.invoiceId);
+    final existing = await docRef.get();
+    final updateData = {
       'invoiceStatus': 'closed',
       'adminOverride': true,
-    });
+    };
+    if (existing.data()?['closedAt'] == null) {
+      updateData['closedAt'] = FieldValue.serverTimestamp();
+    }
+    await docRef.update(updateData);
 
     await FirebaseFirestore.instance.collection('admin_logs').add({
       'action': 'forceCloseInvoice',

--- a/lib/pages/customer_invoices_page.dart
+++ b/lib/pages/customer_invoices_page.dart
@@ -121,6 +121,8 @@ class CustomerInvoicesPage extends StatelessWidget {
                         Text('Mechanic: $mechanic'),
                         if (carText.isNotEmpty) Text('Vehicle: $carText'),
                         Text('Submitted on ${_formatDate(ts)}'),
+                        if (data['closedAt'] != null)
+                          Text('Closed on ${_formatDate(data['closedAt'] as Timestamp?)}'),
                         if (finalPrice != null)
                           Text('Final Price: \\$${finalPrice.toStringAsFixed(2)}'),
                       ],

--- a/lib/pages/customer_request_history_page.dart
+++ b/lib/pages/customer_request_history_page.dart
@@ -166,14 +166,20 @@ class _CustomerRequestHistoryPageState extends State<CustomerRequestHistoryPage>
                                       children: [
                                         ElevatedButton(
                                           onPressed: () async {
-                                            await FirebaseFirestore.instance
+                                            final docRef = FirebaseFirestore.instance
                                                 .collection('invoices')
-                                                .doc(doc.id)
-                                                .update({
+                                                .doc(doc.id);
+                                            final existing = await docRef.get();
+                                            final updateData = {
                                               'invoiceStatus': 'closed',
                                               'status': 'closed',
                                               'customerConfirmed': true
-                                            });
+                                            };
+                                            if (existing.data()?['closedAt'] == null) {
+                                              updateData['closedAt'] =
+                                                  FieldValue.serverTimestamp();
+                                            }
+                                            await docRef.update(updateData);
                                             if (context.mounted) {
                                               ScaffoldMessenger.of(context).showSnackBar(
                                                 const SnackBar(content: Text('Price accepted. Invoice closed.')),

--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -1036,14 +1036,19 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
                             },
                           );
                           if (confirmed == true) {
-                            await FirebaseFirestore.instance
+                            final docRef = FirebaseFirestore.instance
                                 .collection('invoices')
-                                .doc(widget.invoiceId)
-                                .update({
+                                .doc(widget.invoiceId);
+                            final existing = await docRef.get();
+                            final updateData = {
                               'invoiceStatus': 'closed',
                               'status': 'closed',
                               'customerConfirmed': true,
-                            });
+                            };
+                            if (existing.data()?['closedAt'] == null) {
+                              updateData['closedAt'] = FieldValue.serverTimestamp();
+                            }
+                            await docRef.update(updateData);
                             if (context.mounted) {
                               ScaffoldMessenger.of(context).showSnackBar(
                                 const SnackBar(content: Text('Price accepted. Invoice closed.')),

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -1356,15 +1356,19 @@ class _ActiveRequestCard extends StatelessWidget {
 
       if (confirmed == true) {
         final double fee = double.parse((price * 0.15).toStringAsFixed(2));
-        await FirebaseFirestore.instance
-            .collection('invoices')
-            .doc(invoiceId)
-            .update({
+        final docRef =
+            FirebaseFirestore.instance.collection('invoices').doc(invoiceId);
+        final existing = await docRef.get();
+        final updateData = {
           'status': 'completed',
           'finalPrice': price,
           'postJobNotes': notes,
           'platformFee': fee,
-        });
+        };
+        if (existing.data()?['closedAt'] == null) {
+          updateData['closedAt'] = FieldValue.serverTimestamp();
+        }
+        await docRef.update(updateData);
         await FirebaseFirestore.instance
             .collection('users')
             .doc(mechanicId)


### PR DESCRIPTION
## Summary
- record `closedAt` on invoice completion or forced closure
- show closed date in admin invoice list and customer invoices list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cd5499298832f9c7d9cfd90b31138