### PR TITLE
Add emergency support page

### DIFF
--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -14,6 +14,7 @@ import 'customer_invoices_page.dart';
 import 'customer_profile_page.dart';
 import 'customer_request_history_page.dart';
 import 'customer_notifications_page.dart';
+import 'emergency_support_page.dart';
 
 class CustomerDashboard extends StatefulWidget {
   final String userId;
@@ -1061,6 +1062,21 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
             icon: const Icon(Icons.person, color: Colors.white),
             label: const Text(
               'Profile',
+              style: TextStyle(color: Colors.white),
+            ),
+          ),
+          TextButton.icon(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const EmergencySupportPage(),
+                ),
+              );
+            },
+            icon: const Icon(Icons.help, color: Colors.white),
+            label: const Text(
+              'Support',
               style: TextStyle(color: Colors.white),
             ),
           ),

--- a/lib/pages/emergency_support_page.dart
+++ b/lib/pages/emergency_support_page.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'terms_of_service_page.dart';
+
+/// Page with emergency contact info and dispute instructions for customers.
+class EmergencySupportPage extends StatelessWidget {
+  const EmergencySupportPage({super.key});
+
+  Future<void> _emailSupport() async {
+    final uri = Uri.parse('mailto:support@skiptow.com');
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Emergency Support'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'For urgent issues, mechanic no-shows, or payment disputes, '
+              'please contact our support team immediately. Include your '
+              'invoice number or job details so we can assist quickly.',
+            ),
+            const SizedBox(height: 20),
+            Center(
+              child: ElevatedButton(
+                onPressed: _emailSupport,
+                child: const Text('Email support@skiptow.com'),
+              ),
+            ),
+            const SizedBox(height: 20),
+            TextButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const TermsOfServicePage(),
+                  ),
+                );
+              },
+              child: const Text('View Terms & Conditions'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add emergency support page
- link to it from Customer Dashboard

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687cd7d9e634832f87dc79cdd45d5dd0