### PR TITLE
Add Account Settings page

### DIFF
--- a/lib/pages/account_settings_page.dart
+++ b/lib/pages/account_settings_page.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import 'login_page.dart';
+
+/// Displays basic account settings and information for the logged in user.
+class AccountSettingsPage extends StatefulWidget {
+  final String userId;
+
+  const AccountSettingsPage({super.key, required this.userId});
+
+  @override
+  State<AccountSettingsPage> createState() => _AccountSettingsPageState();
+}
+
+class _AccountSettingsPageState extends State<AccountSettingsPage> {
+  late final Future<Map<String, dynamic>> _userFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _userFuture = _loadUserData();
+  }
+
+  Future<Map<String, dynamic>> _loadUserData() async {
+    final doc = await FirebaseFirestore.instance
+        .collection('users')
+        .doc(widget.userId)
+        .get();
+    final data = doc.data() ?? {};
+    return {
+      'username': data['username'],
+      'email': data['email'],
+      'role': data['role'],
+      'radiusMiles': data['radiusMiles'],
+      'isActive': data['isActive'],
+      'unavailable': data['unavailable'],
+    };
+  }
+
+  Future<void> _logout() async {
+    await FirebaseAuth.instance.signOut();
+    if (mounted) {
+      Navigator.pushAndRemoveUntil(
+        context,
+        MaterialPageRoute(builder: (_) => const LoginPage()),
+        (route) => false,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Account Settings')),
+      body: FutureBuilder<Map<String, dynamic>>(
+        future: _userFuture,
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            return const Center(child: Text('Unable to load account data'));
+          }
+
+          final data = snapshot.data!;
+          final role = data['role'] ?? 'N/A';
+          final isMechanic = role == 'mechanic';
+
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Username: ${data['username'] ?? 'N/A'}'),
+                Text('Email: ${data['email'] ?? 'N/A'}'),
+                Text('Role: $role'),
+                if (isMechanic) ...[
+                  const SizedBox(height: 20),
+                  Text('Radius: ${data['radiusMiles']?.toString() ?? 'N/A'} miles'),
+                  Text('Status: ${(data['isActive'] ?? false) ? 'Active' : 'Inactive'}'),
+                  Text('Temporarily Unavailable: ${(data['unavailable'] ?? false) ? 'Yes' : 'No'}'),
+                ],
+                const Spacer(),
+                ElevatedButton(
+                  onPressed: _logout,
+                  child: const Text('Log Out'),
+                ),
+                const SizedBox(height: 12),
+                ElevatedButton(
+                  onPressed: null,
+                  child: const Text('Delete My Account'),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -12,6 +12,7 @@ import 'service_request_history_page.dart';
 import 'messages_page.dart';
 import 'customer_invoices_page.dart';
 import 'customer_profile_page.dart';
+import 'account_settings_page.dart';
 import 'customer_request_history_page.dart';
 import 'customer_notifications_page.dart';
 import 'emergency_support_page.dart';
@@ -1090,30 +1091,45 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
             label: const Text(
               'Service History',
               style: TextStyle(color: Colors.white),
-            ),
           ),
-          TextButton.icon(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => CustomerProfilePage(
-                    userId: widget.userId,
-                  ),
+        ),
+        TextButton.icon(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => CustomerProfilePage(
+                  userId: widget.userId,
                 ),
-              );
-            },
-            icon: const Icon(Icons.person, color: Colors.white),
-            label: const Text(
-              'Profile',
-              style: TextStyle(color: Colors.white),
-            ),
+              ),
+            );
+          },
+          icon: const Icon(Icons.person, color: Colors.white),
+          label: const Text(
+            'Profile',
+            style: TextStyle(color: Colors.white),
           ),
-          TextButton.icon(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
+        ),
+        TextButton.icon(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => AccountSettingsPage(userId: widget.userId),
+              ),
+            );
+          },
+          icon: const Icon(Icons.settings, color: Colors.white),
+          label: const Text(
+            'Account Settings',
+            style: TextStyle(color: Colors.white),
+          ),
+        ),
+        TextButton.icon(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
                   builder: (_) => const EmergencySupportPage(),
                 ),
               );

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -12,6 +12,7 @@ import 'mechanic_request_queue_page.dart';
 import 'mechanic_requests_page.dart';
 import 'mechanic_job_history_page.dart';
 import 'mechanic_profile_page.dart';
+import 'account_settings_page.dart';
 import 'mechanic_earnings_report_page.dart';
 import 'mechanic_notifications_page.dart';
 import 'mechanic_radius_history_page.dart';
@@ -804,6 +805,21 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
             icon: const Icon(Icons.person, color: Colors.white),
             label: const Text(
               'Profile',
+              style: TextStyle(color: Colors.white),
+            ),
+          ),
+          TextButton.icon(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => AccountSettingsPage(userId: widget.userId),
+                ),
+              );
+            },
+            icon: const Icon(Icons.settings, color: Colors.white),
+            label: const Text(
+              'Account Settings',
               style: TextStyle(color: Colors.white),
             ),
           ),


### PR DESCRIPTION
## Summary
- add shared Account Settings page showing account info and logout
- link Account Settings from mechanic and customer dashboards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cecd55ae8832fab2d51157d45b9ce