### PR TITLE
Add Terms & Conditions Page

### DIFF
--- a/lib/pages/emergency_support_page.dart
+++ b/lib/pages/emergency_support_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'terms_of_service_page.dart';
+import 'terms_and_conditions_page.dart';
 
 /// Page with emergency contact info and dispute instructions for customers.
 class EmergencySupportPage extends StatelessWidget {
@@ -42,7 +42,7 @@ class EmergencySupportPage extends StatelessWidget {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (_) => const TermsOfServicePage(),
+                    builder: (_) => const TermsAndConditionsPage(),
                   ),
                 );
               },

--- a/lib/pages/signup_page.dart
+++ b/lib/pages/signup_page.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:skiptow/pages/privacy_policy_page.dart';
 import 'package:skiptow/pages/terms_of_service_page.dart';
+import 'package:skiptow/pages/terms_and_conditions_page.dart';
 
 class SignupPage extends StatefulWidget {
   const SignupPage({super.key});
@@ -107,34 +108,46 @@ class _SignupPageState extends State<SignupPage> {
             const SizedBox(height: 12),
             Text(_status, style: const TextStyle(color: Colors.red)),
             const SizedBox(height: 20),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                TextButton(
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => const TermsOfServicePage(),
-                      ),
-                    );
-                  },
-                  child: const Text('Terms of Service'),
-                ),
-                const SizedBox(width: 16),
-                TextButton(
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => const PrivacyPolicyPage(),
-                      ),
-                    );
-                  },
-                  child: const Text('Privacy Policy'),
-                ),
-              ],
-            ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  TextButton(
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const TermsOfServicePage(),
+                        ),
+                      );
+                    },
+                    child: const Text('Terms of Service'),
+                  ),
+                  const SizedBox(width: 16),
+                  TextButton(
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const TermsAndConditionsPage(),
+                        ),
+                      );
+                    },
+                    child: const Text('Terms & Conditions'),
+                  ),
+                  const SizedBox(width: 16),
+                  TextButton(
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const PrivacyPolicyPage(),
+                        ),
+                      );
+                    },
+                    child: const Text('Privacy Policy'),
+                  ),
+                ],
+              ),
           ],
         ),
       ),

--- a/lib/pages/terms_and_conditions_page.dart
+++ b/lib/pages/terms_and_conditions_page.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+/// Displays legal terms and conditions.
+class TermsAndConditionsPage extends StatelessWidget {
+  const TermsAndConditionsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Terms & Conditions'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ),
+      body: Column(
+        children: [
+          const Expanded(
+            child: SingleChildScrollView(
+              padding: EdgeInsets.all(16),
+              child: Text(
+                'These terms and conditions are provided as a placeholder. '
+                'Replace this text with your actual legal agreement.\n\n'
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. '
+                'Suspendisse potenti. Nulla facilisi.\n\n'
+                'Aliquam erat volutpat. Donec consequat, nunc eget gravida '
+                'tincidunt, lorem mauris ultrices dui, a hendrerit turpis '
+                'massa id velit.\n\n'
+                'Curabitur vehicula, nisl sit amet varius dignissim, orci '
+                'diam dictum arcu, et tempor metus nisi eget leo.',
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: ElevatedButton(
+              onPressed: () {},
+              child: const Text('I Agree'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `TermsAndConditionsPage` with placeholder legal text and "I Agree" button
- link to the new page from Emergency Support
- make signup page reference the terms & conditions

## Testing
- `dart format lib/pages/terms_and_conditions_page.dart lib/pages/emergency_support_page.dart lib/pages/signup_page.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d09e875e0832fb1934977211875cf