### PR TITLE
Add dark mode support

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -194,9 +194,21 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData lightTheme =
+        ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange));
+    final ThemeData darkTheme = ThemeData(
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: Colors.orange,
+        brightness: Brightness.dark,
+      ),
+    );
+
     if (_loading || _maintenanceMode == null) {
       return MaterialApp(
         navigatorKey: navigatorKey,
+        theme: lightTheme,
+        darkTheme: darkTheme,
+        themeMode: ThemeMode.system,
         home: const Scaffold(
           body: Center(child: CircularProgressIndicator()),
         ),
@@ -207,7 +219,9 @@ class _MyAppState extends State<MyApp> {
         navigatorKey: navigatorKey,
         title: 'SkipTow',
         debugShowCheckedModeBanner: false,
-        theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange)),
+        theme: lightTheme,
+        darkTheme: darkTheme,
+        themeMode: ThemeMode.system,
         home: MaintenanceModePage(message: _maintenanceMessage),
       );
     }
@@ -215,7 +229,9 @@ class _MyAppState extends State<MyApp> {
       navigatorKey: navigatorKey,
       title: 'SkipTow',
       debugShowCheckedModeBanner: false,
-      theme: ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange)),
+      theme: lightTheme,
+      darkTheme: darkTheme,
+      themeMode: ThemeMode.system,
       home: _currentUserId != null
           ? DashboardPage(userId: _currentUserId!)
           : const LoginPage(),

--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -1167,10 +1167,13 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
                 ),
               );
             },
-            icon: const Icon(Icons.receipt, color: Colors.white),
-            label: const Text(
+            icon: Icon(
+              Icons.receipt,
+              color: Theme.of(context).colorScheme.onPrimary,
+            ),
+            label: Text(
               'My Invoices',
-              style: TextStyle(color: Colors.white),
+              style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
             ),
           ),
           TextButton.icon(
@@ -1184,12 +1187,15 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
                 ),
               );
             },
-            icon: const Icon(Icons.history, color: Colors.white),
-            label: const Text(
+            icon: Icon(
+              Icons.history,
+              color: Theme.of(context).colorScheme.onPrimary,
+            ),
+            label: Text(
               'Service History',
-              style: TextStyle(color: Colors.white),
+              style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
+            ),
           ),
-        ),
         TextButton.icon(
           onPressed: () {
             Navigator.push(
@@ -1201,10 +1207,13 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
               ),
             );
           },
-          icon: const Icon(Icons.person, color: Colors.white),
-          label: const Text(
+          icon: Icon(
+            Icons.person,
+            color: Theme.of(context).colorScheme.onPrimary,
+          ),
+          label: Text(
             'Profile',
-            style: TextStyle(color: Colors.white),
+            style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
           ),
         ),
         TextButton.icon(
@@ -1216,10 +1225,13 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
               ),
             );
           },
-          icon: const Icon(Icons.settings, color: Colors.white),
-          label: const Text(
+          icon: Icon(
+            Icons.settings,
+            color: Theme.of(context).colorScheme.onPrimary,
+          ),
+          label: Text(
             'Account Settings',
-            style: TextStyle(color: Colors.white),
+            style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
           ),
         ),
         TextButton.icon(
@@ -1231,10 +1243,13 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
                 ),
               );
             },
-            icon: const Icon(Icons.help, color: Colors.white),
-            label: const Text(
+            icon: Icon(
+              Icons.help,
+              color: Theme.of(context).colorScheme.onPrimary,
+            ),
+            label: Text(
               'Support',
-              style: TextStyle(color: Colors.white),
+              style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
             ),
           ),
           _buildMessagesIcon(),

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -964,10 +964,13 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                 ),
               );
             },
-            icon: const Icon(Icons.person, color: Colors.white),
-            label: const Text(
+            icon: Icon(
+              Icons.person,
+              color: Theme.of(context).colorScheme.onPrimary,
+            ),
+            label: Text(
               'Profile',
-              style: TextStyle(color: Colors.white),
+              style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
             ),
           ),
           TextButton.icon(
@@ -979,10 +982,13 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                 ),
               );
             },
-            icon: const Icon(Icons.settings, color: Colors.white),
-            label: const Text(
+            icon: Icon(
+              Icons.settings,
+              color: Theme.of(context).colorScheme.onPrimary,
+            ),
+            label: Text(
               'Account Settings',
-              style: TextStyle(color: Colors.white),
+              style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
             ),
           ),
           _buildMessagesIcon(),


### PR DESCRIPTION
## Summary
- detect system theme and enable dark mode
- adapt colors in customer and mechanic dashboards to respect dark theme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d107119b4832f97386eaa190011b4