### PR TITLE
Add loading indicators for Firestore reads

### DIFF
--- a/lib/pages/admin_customer_history_page.dart
+++ b/lib/pages/admin_customer_history_page.dart
@@ -311,6 +311,13 @@ class _AdminCustomerHistoryPageState extends State<AdminCustomerHistoryPage> {
                                       .get()
                                   : Future.value(null),
                               builder: (context, snap) {
+                                if (snap.connectionState == ConnectionState.waiting) {
+                                  return const SizedBox(
+                                    height: 16,
+                                    width: 16,
+                                    child: CircularProgressIndicator(strokeWidth: 2),
+                                  );
+                                }
                                 final name = snap.data?.data()?['username'] ?? 'Unknown';
                                 return Text('Mechanic: $name');
                               },

--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -654,6 +654,9 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
       stream: stream,
       builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
         final docs = snapshot.hasData
             ? snapshot.data!.docs
                 .where((d) => d.data()['flagged'] != true)
@@ -695,6 +698,9 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
       stream: stream,
       builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
         final docs = snapshot.hasData
             ? snapshot.data!.docs
                 .where((d) => d.data()['flagged'] != true)
@@ -727,6 +733,9 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
       stream: stream,
       builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
         final docs = snapshot.hasData
             ? snapshot.data!.docs
                 .where((d) => d.data()['flagged'] != true)
@@ -789,6 +798,9 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
       stream: stream,
       builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
         final docs = snapshot.hasData
             ? snapshot.data!.docs
                 .where((d) => d.data()['flagged'] != true)
@@ -832,6 +844,9 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
       stream: stream,
       builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
         final docs = snapshot.hasData
             ? snapshot.data!.docs
                 .where((d) => d.data()['flagged'] != true)
@@ -1293,6 +1308,9 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
                         .limit(1)
                         .snapshots(),
                     builder: (context, snapshot) {
+                      if (snapshot.connectionState == ConnectionState.waiting) {
+                        return const Center(child: CircularProgressIndicator());
+                      }
                       final docs = snapshot.hasData
                           ? snapshot.data!.docs
                               .where((d) => d.data()['flagged'] != true)

--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -888,6 +888,9 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
                   .doc(widget.invoiceId)
                   .snapshots(),
               builder: (context, paySnapshot) {
+                if (paySnapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
                 if (!paySnapshot.hasData) {
                   return const SizedBox.shrink();
                 }

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -1013,6 +1013,12 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                       .where('mechanicId', isEqualTo: widget.userId)
                       .snapshots(),
                   builder: (context, snapshot) {
+                    if (snapshot.connectionState == ConnectionState.waiting) {
+                      return const Padding(
+                        padding: EdgeInsets.all(8),
+                        child: CircularProgressIndicator(),
+                      );
+                    }
                     final docs = snapshot.data?.docs ?? [];
                     final filtered = docs.where((d) {
                       final data = d.data();
@@ -1082,6 +1088,12 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                       .where('status', isEqualTo: 'active')
                       .snapshots(),
                   builder: (context, snapshot) {
+                    if (snapshot.connectionState == ConnectionState.waiting) {
+                      return const Padding(
+                        padding: EdgeInsets.all(8),
+                        child: CircularProgressIndicator(),
+                      );
+                    }
                     final activeCount = snapshot.hasData ? snapshot.data!.docs.where((d) => d.data()["flagged"] != true).length : 0;
                     return Padding(
                       padding: const EdgeInsets.all(8),
@@ -1101,6 +1113,12 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                       .doc(widget.userId)
                       .snapshots(),
                   builder: (context, snapshot) {
+                    if (snapshot.connectionState == ConnectionState.waiting) {
+                      return const Padding(
+                        padding: EdgeInsets.all(8),
+                        child: CircularProgressIndicator(),
+                      );
+                    }
                     final data = snapshot.data?.data();
                     final completedCount = data?['completedJobs'] ?? completedJobs;
                     final blocked = data?['blocked'] == true;
@@ -1273,6 +1291,12 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
             .limit(1)
             .snapshots(),
         builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const FloatingActionButton(
+              onPressed: null,
+              child: CircularProgressIndicator(),
+            );
+          }
           final docs = (snapshot.data?.docs ?? [])
               .where((d) => d.data()['flagged'] != true)
               .toList();

--- a/lib/pages/mechanic_job_history_page.dart
+++ b/lib/pages/mechanic_job_history_page.dart
@@ -123,6 +123,13 @@ class MechanicJobHistoryPage extends StatelessWidget {
                               .doc(data['customerId'])
                               .get(),
                           builder: (context, snap) {
+                            if (snap.connectionState == ConnectionState.waiting) {
+                              return const SizedBox(
+                                height: 16,
+                                width: 16,
+                                child: CircularProgressIndicator(strokeWidth: 2),
+                              );
+                            }
                             final username = snap.data?.data()?['username'] ?? 'Unknown';
                             return Text('Customer: $username');
                           },


### PR DESCRIPTION
## Summary
- add progress spinners in CustomerDashboard stream builders
- show loader for mechanic dashboard metrics and actions
- display loader for payment status on invoice detail
- include loading indicators in history pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d13528834832fa72f4285e21c923c