### PR TITLE
Add payment issue reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ SkipTow is currently open source for community contributions; it may become clos
 - In-app chat thread on each invoice with photo attachments
 - View and manage all service requests, invoices and vehicle history
 - Receive push notifications for request updates and payment reminders
+- Report payment issues after confirming final price
 - Access emergency support and app help pages
 - Manage profile, saved vehicles and account settings
 


### PR DESCRIPTION
## Summary
- let customers report payment issues from Invoice detail
- store payment issue reports in Firestore
- document this capability

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d1b275780832f86008f85c275b11c