### PR TITLE
Fix admin invoice finalize display logic

### DIFF
--- a/lib/pages/admin_invoice_detail_page.dart
+++ b/lib/pages/admin_invoice_detail_page.dart
@@ -467,21 +467,23 @@ class _AdminInvoiceDetailPageState extends State<AdminInvoiceDetailPage> {
           ],
         ),
         const SizedBox(height: 8),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            ElevatedButton(
-              onPressed: _forceCloseInvoice,
-              style: ElevatedButton.styleFrom(backgroundColor: Colors.orange),
-              child: const Text('Force Close Invoice'),
-            ),
-            ElevatedButton(
-              onPressed: _forceCancelInvoice,
-              style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
-              child: const Text('Force Cancel Invoice'),
-            ),
-          ],
-        ),
+        if (data['invoiceStatus'] != 'closed' &&
+            data['invoiceStatus'] != 'cancelled')
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              ElevatedButton(
+                onPressed: _forceCloseInvoice,
+                style: ElevatedButton.styleFrom(backgroundColor: Colors.orange),
+                child: const Text('Force Close Invoice'),
+              ),
+              ElevatedButton(
+                onPressed: _forceCancelInvoice,
+                style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+                child: const Text('Force Cancel Invoice'),
+              ),
+            ],
+          ),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- show admin Force Close/Cancel buttons only when an invoice isn't already closed or cancelled

## Testing
- `grep -n "Force Close" -n lib/pages/admin_invoice_detail_page.dart`

------
https://chatgpt.com/codex/tasks/task_e_687d2879cda8832fa81916f7b2e67715