### PR TITLE
Add general messaging and support system

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ firebase_options.dart
 - maintenanceMode: `true` or `false`
 - maintenanceMessage: string
 
+## General Messaging & Support
+- Admin can message any user outside of invoices.
+- Users can chat with support/admin directly.
+- All chats stored in Firestore (`messages_general`).
+- Admin receives visual notifications in the admin dashboard.
+
 ## Setup Instructions
 
 1. Clone the repository.

--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -15,6 +15,7 @@ import 'admin_mechanic_performance_page.dart';
 import 'admin_customer_history_page.dart';
 import 'admin_broadcast_message_page.dart';
 import 'admin_report_detail_page.dart';
+import 'admin_message_center_page.dart';
 
 /// Simple admin dashboard for monitoring the platform.
 class AdminDashboardPage extends StatefulWidget {
@@ -745,6 +746,48 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
         (route) => false,
       );
     }
+  }
+
+  Widget _buildMessageCenterIcon() {
+    final stream = FirebaseFirestore.instance
+        .collection('notifications_admin')
+        .where('unread', isEqualTo: true)
+        .snapshots();
+    return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+      stream: stream,
+      builder: (context, snapshot) {
+        final count = snapshot.data?.docs.length ?? 0;
+        return Stack(
+          children: [
+            IconButton(
+              icon: const Icon(Icons.support_agent),
+              tooltip: 'Message Center',
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => AdminMessageCenterPage(adminId: widget.userId),
+                  ),
+                );
+              },
+            ),
+            if (count > 0)
+              Positioned(
+                right: 4,
+                top: 4,
+                child: CircleAvatar(
+                  radius: 8,
+                  backgroundColor: Colors.red,
+                  child: Text(
+                    '$count',
+                    style: const TextStyle(fontSize: 10, color: Colors.white),
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
   }
 
   Widget _summaryCard(String title, String value, Color color) {
@@ -2108,6 +2151,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
           appBar: AppBar(
             title: const Text('Admin Dashboard'),
             actions: [
+              _buildMessageCenterIcon(),
               IconButton(
                 icon: const Icon(Icons.logout),
                 onPressed: _logout,

--- a/lib/pages/admin_message_center_page.dart
+++ b/lib/pages/admin_message_center_page.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'general_chat_page.dart';
+
+/// Page for admins to manage general message threads with any user.
+class AdminMessageCenterPage extends StatelessWidget {
+  final String adminId;
+  const AdminMessageCenterPage({super.key, required this.adminId});
+
+  Future<void> _startNewChat(BuildContext context) async {
+    final controller = TextEditingController();
+    final username = await showDialog<String>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Enter Username'),
+          content: TextField(
+            controller: controller,
+            decoration: const InputDecoration(labelText: 'Username'),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pop(context, controller.text.trim());
+              },
+              child: const Text('Chat'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (username == null || username.isEmpty) return;
+    final snap = await FirebaseFirestore.instance
+        .collection('users')
+        .where('username', isEqualTo: username)
+        .limit(1)
+        .get();
+    if (snap.docs.isEmpty) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('User not found')));
+      }
+      return;
+    }
+    final userId = snap.docs.first.id;
+    _openThreadWithUser(context, userId, username);
+  }
+
+  Future<void> _openThreadWithUser(
+      BuildContext context, String userId, String username) async {
+    String? threadId;
+    final snapshot = await FirebaseFirestore.instance
+        .collection('messages_general')
+        .where('participants', arrayContains: adminId)
+        .get();
+    for (final doc in snapshot.docs) {
+      final parts = List<String>.from(doc.data()['participants'] ?? []);
+      if (parts.contains(userId)) {
+        threadId = doc.id;
+        break;
+      }
+    }
+    if (threadId == null) {
+      final ref = FirebaseFirestore.instance.collection('messages_general').doc();
+      await ref.set({
+        'participants': [adminId, userId],
+        'lastMessage': '',
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+      threadId = ref.id;
+    }
+    if (context.mounted) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => GeneralChatPage(
+            threadId: threadId!,
+            currentUserId: adminId,
+            otherUserId: userId,
+            otherUsername: username,
+            currentUsername: 'Admin',
+            currentUserRole: 'admin',
+          ),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final stream = FirebaseFirestore.instance
+        .collection('messages_general')
+        .where('participants', arrayContains: adminId)
+        .orderBy('updatedAt', descending: true)
+        .snapshots();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Message Center'),
+        actions: [
+          IconButton(
+            onPressed: () => _startNewChat(context),
+            icon: const Icon(Icons.add_comment),
+            tooltip: 'New Chat',
+          ),
+        ],
+      ),
+      body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+        stream: stream,
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final docs = snapshot.data!.docs;
+          if (docs.isEmpty) {
+            return const Center(child: Text('No message threads'));
+          }
+          return ListView.builder(
+            itemCount: docs.length,
+            itemBuilder: (context, index) {
+              final data = docs[index].data();
+              final parts = List<String>.from(data['participants'] ?? []);
+              parts.remove(adminId);
+              final otherId = parts.isNotEmpty ? parts.first : '';
+              final Timestamp? ts = data['updatedAt'];
+              final last = data['lastMessage'] ?? '';
+              return FutureBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+                future: FirebaseFirestore.instance
+                    .collection('users')
+                    .doc(otherId)
+                    .get(),
+                builder: (context, snap) {
+                  final name = snap.data?.data()?['username'] ?? otherId;
+                  return ListTile(
+                    title: Text(name),
+                    subtitle: Text(last),
+                    trailing: Text(
+                      ts != null
+                          ? DateFormat('MM/dd h:mm a')
+                              .format(ts.toDate().toLocal())
+                          : '',
+                      style: const TextStyle(fontSize: 12),
+                    ),
+                    onTap: () => _openThreadWithUser(context, otherId, name),
+                  );
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -16,6 +16,7 @@ import 'account_settings_page.dart';
 import 'customer_request_history_page.dart';
 import 'customer_notifications_page.dart';
 import 'emergency_support_page.dart';
+import 'help_support_page.dart';
 import 'customer_mechanic_tracking_page.dart';
 import 'invoice_detail_page.dart';
 
@@ -1246,6 +1247,27 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
           ),
           label: Text(
             'Account Settings',
+            style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
+          ),
+        ),
+        TextButton.icon(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => HelpSupportPage(
+                  userId: widget.userId,
+                  userRole: 'customer',
+                ),
+              ),
+            );
+          },
+          icon: Icon(
+            Icons.support_agent,
+            color: Theme.of(context).colorScheme.onPrimary,
+          ),
+          label: Text(
+            'Help & Support',
             style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
           ),
         ),

--- a/lib/pages/general_chat_page.dart
+++ b/lib/pages/general_chat_page.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:intl/intl.dart';
+
+/// Simple chat page for general messaging threads.
+class GeneralChatPage extends StatefulWidget {
+  final String threadId;
+  final String currentUserId;
+  final String otherUserId;
+  final String otherUsername;
+  final String currentUsername;
+  final String currentUserRole; // admin/customer/mechanic
+
+  const GeneralChatPage({
+    super.key,
+    required this.threadId,
+    required this.currentUserId,
+    required this.otherUserId,
+    required this.otherUsername,
+    required this.currentUsername,
+    required this.currentUserRole,
+  });
+
+  @override
+  State<GeneralChatPage> createState() => _GeneralChatPageState();
+}
+
+class _GeneralChatPageState extends State<GeneralChatPage> {
+  final TextEditingController _controller = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  String _formatTimestamp(Timestamp? ts) {
+    if (ts == null) return '';
+    final dt = ts.toDate().toLocal();
+    return DateFormat('MM/dd h:mm a').format(dt);
+  }
+
+  Future<void> _sendMessage() async {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+
+    await FirebaseFirestore.instance
+        .collection('messages_general')
+        .doc(widget.threadId)
+        .collection('messages')
+        .add({
+      'senderId': widget.currentUserId,
+      'senderRole': widget.currentUserRole,
+      'messageText': text,
+      'timestamp': FieldValue.serverTimestamp(),
+    });
+
+    await FirebaseFirestore.instance
+        .collection('messages_general')
+        .doc(widget.threadId)
+        .update({
+      'lastMessage': text,
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+
+    if (widget.currentUserRole != 'admin') {
+      await FirebaseFirestore.instance.collection('notifications_admin').add({
+        'threadId': widget.threadId,
+        'userId': widget.currentUserId,
+        'username': widget.currentUsername,
+        'messagePreview': text.length > 50 ? text.substring(0, 50) : text,
+        'unread': true,
+        'timestamp': FieldValue.serverTimestamp(),
+      });
+    }
+
+    _controller.clear();
+    _scrollToBottom();
+  }
+
+  void _scrollToBottom() {
+    if (_scrollController.hasClients) {
+      _scrollController.animateTo(
+        _scrollController.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final stream = FirebaseFirestore.instance
+        .collection('messages_general')
+        .doc(widget.threadId)
+        .collection('messages')
+        .orderBy('timestamp', descending: false)
+        .snapshots();
+
+    return Scaffold(
+      appBar: AppBar(title: Text('Chat with ${widget.otherUsername}')),
+      body: Column(
+        children: [
+          Expanded(
+            child: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+              stream: stream,
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                final docs = snapshot.data!.docs;
+                WidgetsBinding.instance
+                    .addPostFrameCallback((_) => _scrollToBottom());
+                return ListView.builder(
+                  controller: _scrollController,
+                  padding: const EdgeInsets.all(8),
+                  itemCount: docs.length,
+                  itemBuilder: (context, index) {
+                    final data = docs[index].data();
+                    final isMe = data['senderId'] == widget.currentUserId;
+                    final alignment =
+                        isMe ? Alignment.centerRight : Alignment.centerLeft;
+                    final color = isMe ? Colors.blue[100] : Colors.grey[300];
+                    final Timestamp? ts = data['timestamp'];
+                    return Align(
+                      alignment: alignment,
+                      child: Column(
+                        crossAxisAlignment: isMe
+                            ? CrossAxisAlignment.end
+                            : CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            margin: const EdgeInsets.symmetric(vertical: 2),
+                            padding: const EdgeInsets.all(8),
+                            decoration: BoxDecoration(
+                              color: color,
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Text(data['messageText'] ?? ''),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            _formatTimestamp(ts),
+                            style: const TextStyle(
+                                fontSize: 12, color: Colors.black54),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _controller,
+                      decoration: const InputDecoration(
+                        hintText: 'Type a message',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  IconButton(
+                    icon: const Icon(Icons.send),
+                    onPressed: _sendMessage,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/help_support_page.dart
+++ b/lib/pages/help_support_page.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'general_chat_page.dart';
+
+/// Help page allowing customers and mechanics to chat with support.
+class HelpSupportPage extends StatelessWidget {
+  final String userId;
+  final String userRole; // customer or mechanic
+  const HelpSupportPage({super.key, required this.userId, required this.userRole});
+
+  Future<String?> _getAdminId() async {
+    final snap = await FirebaseFirestore.instance
+        .collection('users')
+        .where('role', isEqualTo: 'admin')
+        .limit(1)
+        .get();
+    if (snap.docs.isEmpty) return null;
+    return snap.docs.first.id;
+  }
+
+  Future<String?> _getUsername(String id) async {
+    final doc = await FirebaseFirestore.instance.collection('users').doc(id).get();
+    return doc.data()?['username'] as String?;
+  }
+
+  Future<void> _startChat(BuildContext context) async {
+    final adminId = await _getAdminId();
+    if (adminId == null) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Support unavailable')));
+      }
+      return;
+    }
+
+    String? threadId;
+    final existing = await FirebaseFirestore.instance
+        .collection('messages_general')
+        .where('participants', arrayContains: userId)
+        .get();
+    for (final doc in existing.docs) {
+      final parts = List<String>.from(doc.data()['participants'] ?? []);
+      if (parts.contains(adminId)) {
+        threadId = doc.id;
+        break;
+      }
+    }
+    if (threadId == null) {
+      final ref = FirebaseFirestore.instance.collection('messages_general').doc();
+      await ref.set({
+        'participants': [userId, adminId],
+        'lastMessage': '',
+        'updatedAt': FieldValue.serverTimestamp(),
+      });
+      threadId = ref.id;
+    }
+
+    final username = await _getUsername(userId) ?? 'User';
+
+    if (context.mounted) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => GeneralChatPage(
+            threadId: threadId!,
+            currentUserId: userId,
+            otherUserId: adminId,
+            otherUsername: 'Admin',
+            currentUsername: username,
+            currentUserRole: userRole,
+          ),
+        ),
+      );
+    }
+  }
+
+  Widget _sectionTitle(String text) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 16.0, bottom: 8.0),
+      child: Text(text,
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Help & Support')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _sectionTitle('FAQ'),
+            const Text(
+                'Browse our frequently asked questions or start a chat below if you need more help.'),
+            const SizedBox(height: 20),
+            Center(
+              child: ElevatedButton(
+                onPressed: () => _startChat(context),
+                child: const Text('Chat with Support'),
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Text('This does not request a mechanic!'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -18,6 +18,7 @@ import 'mechanic_earnings_report_page.dart';
 import 'mechanic_notifications_page.dart';
 import 'mechanic_radius_history_page.dart';
 import 'mechanic_location_history_page.dart';
+import 'help_support_page.dart';
 import '../services/alert_service.dart';
 import 'mechanic_current_job_page.dart';
 import 'invoice_detail_page.dart';
@@ -1050,14 +1051,35 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
               Icons.settings,
               color: Theme.of(context).colorScheme.onPrimary,
             ),
-            label: Text(
-              'Account Settings',
-              style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
-            ),
+          label: Text(
+            'Account Settings',
+            style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
           ),
-          _buildMessagesIcon(),
-          _buildNotificationsIcon(),
-        ],
+        ),
+        TextButton.icon(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => HelpSupportPage(
+                  userId: widget.userId,
+                  userRole: 'mechanic',
+                ),
+              ),
+            );
+          },
+          icon: Icon(
+            Icons.support_agent,
+            color: Theme.of(context).colorScheme.onPrimary,
+          ),
+          label: Text(
+            'Help & Support',
+            style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
+          ),
+        ),
+        _buildMessagesIcon(),
+        _buildNotificationsIcon(),
+      ],
       ),
       body: _blocked
           ? const Center(


### PR DESCRIPTION
## Summary
- implement general chat page for independent message threads
- add admin message center page with ability to start chats
- allow customers and mechanics to open Help & Support page
- show admin notifications count and link to message center
- document new general messaging system in README

## Testing
- `git commit -m "feat: add general messaging support"`

------
https://chatgpt.com/codex/tasks/task_e_687d2dd613d4832f9454bd33438e585b