### PR TITLE
Restrict mechanic access to closed invoices

### DIFF
--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -747,6 +747,17 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
         final location = data['location'];
         final status = data['status'] ?? 'active';
         final invoiceStatus = data['invoiceStatus'] ?? status;
+
+        // Mechanics should not view closed or cancelled invoices
+        if (widget.role == 'mechanic' &&
+            (invoiceStatus == 'closed' || invoiceStatus == 'cancelled')) {
+          return Scaffold(
+            appBar: AppBar(title: const Text('Invoice Details')),
+            body: const Center(
+              child: Text('This job has been closed or cancelled.'),
+            ),
+          );
+        }
         final customerConfirmed = data['customerConfirmed'] == true;
         final finalPrice = data['finalPrice'];
         final estimatedPrice = finalPrice == null


### PR DESCRIPTION
## Summary
- deny access to invoice details when mechanics try to open closed or cancelled jobs

## Testing
- `grep -n "closed or cancelled" -n lib/pages/invoice_detail_page.dart`

------
https://chatgpt.com/codex/tasks/task_e_687d38634efc832f9b7005bdbe3036ad