### PR TITLE
Add bool default helper

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'dart:convert';
 import 'services/push_notification_service.dart';
+import 'utils.dart';
 import 'firebase_options.dart';
 import 'pages/login_page.dart';
 import 'pages/dashboard_page.dart';
@@ -107,7 +108,7 @@ class _MyAppState extends State<MyApp> {
       final data = snap.data();
       if (data != null) {
         setState(() {
-          _maintenanceMode = data['maintenanceMode'] == true;
+          _maintenanceMode = getBool(data, 'maintenanceMode');
           _maintenanceMessage =
               (data['maintenanceMessage'] ?? '').toString();
         });

--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -3,6 +3,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:skiptow/pages/create_invoice_page.dart';
+import '../utils.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:skiptow/services/error_logger.dart';
 import 'package:intl/intl.dart';
@@ -1004,7 +1005,7 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
         .listen((doc) {
       final data = doc.data();
       final loc = data?['location'];
-      final bool active = data?['isActive'] == true;
+      final bool active = getBool(data, 'isActive');
       if (!active || loc == null) {
         _updateLiveMechanicMarker(null);
         return;

--- a/lib/pages/customer_notifications_page.dart
+++ b/lib/pages/customer_notifications_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
+import '../utils.dart';
 
 /// Page that displays notifications for a customer.
 class CustomerNotificationsPage extends StatelessWidget {
@@ -45,7 +46,7 @@ class CustomerNotificationsPage extends StatelessWidget {
               final title = data['title'] ?? '';
               final body = data['body'] ?? '';
               final Timestamp? ts = data['timestamp'];
-              final bool read = data['read'] == true;
+              final bool read = getBool(data, 'read');
               return ListTile(
                 title: Text(
                   title,

--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../utils.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:image_picker/image_picker.dart';
@@ -145,7 +146,7 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
             .doc(data['mechanicId'])
             .get();
         final mechData = mechDoc.data();
-        data['mechanicIsActive'] = mechData?['isActive'];
+        data['mechanicIsActive'] = mechData?['isActive'] ?? false;
 
         final mechLocation = mechData?['location'];
         final invoiceLocation = data['location'];
@@ -890,14 +891,10 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
           }
 
           // Show mechanic availability status to customers
-          final bool? mechActive = data['mechanicIsActive'] as bool?;
-          String statusText = 'Mechanic Status: Unknown';
-          Color? statusColor;
-          if (mechActive != null) {
-            statusText =
-                'Mechanic Status: ${mechActive ? 'Active' : 'Inactive'}';
-            statusColor = mechActive ? Colors.green : Colors.red;
-          }
+          final bool mechActive = getBool(data, 'mechanicIsActive');
+          String statusText =
+              'Mechanic Status: ${mechActive ? 'Active' : 'Inactive'}';
+          Color? statusColor = mechActive ? Colors.green : Colors.red;
           children.add(
             Padding(
               padding: const EdgeInsets.only(bottom: 8),

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -3,6 +3,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:permission_handler/permission_handler.dart';
+import '../utils.dart';
 import 'dart:async';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:skiptow/services/error_logger.dart';
@@ -327,10 +328,10 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
         return;
       }
       setState(() {
-        isActive = data['isActive'] ?? false;
+        isActive = getBool(data, 'isActive');
         radiusMiles = (data['radiusMiles'] ?? 5).toDouble();
         completedJobs = data['completedJobs'] ?? 0;
-        unavailable = data['unavailable'] ?? false;
+        unavailable = getBool(data, 'unavailable');
         if (data.containsKey('location')) {
           currentPosition = Position(
             latitude: data['location']['lat'],

--- a/lib/pages/mechanic_notifications_page.dart
+++ b/lib/pages/mechanic_notifications_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
+import '../utils.dart';
 
 /// Page that displays notifications for a mechanic.
 class MechanicNotificationsPage extends StatelessWidget {
@@ -45,7 +46,7 @@ class MechanicNotificationsPage extends StatelessWidget {
               final title = data['title'] ?? '';
               final body = data['body'] ?? '';
               final Timestamp? ts = data['timestamp'];
-              final bool read = data['read'] == true;
+              final bool read = getBool(data, 'read');
               return ListTile(
                 title: Text(
                   title,

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,0 +1,10 @@
+bool getBool(Map<String, dynamic>? data, String key, {bool defaultValue = false}) {
+  final value = data?[key];
+  if (value is bool) return value;
+  if (value == null) return defaultValue;
+  if (value is num) return value != 0;
+  final str = value.toString().toLowerCase();
+  if (str == 'true') return true;
+  if (str == 'false') return false;
+  return defaultValue;
+}


### PR DESCRIPTION
## Summary
- add helper `getBool` to safely read booleans
- use helper when reading Firestore data in several pages

## Testing
- `dart` not available; skipped formatting/tests

------
https://chatgpt.com/codex/tasks/task_e_687d40d2e34c832f92c277f3bf00406f