### PR TITLE
Add change password placeholder

### DIFF
--- a/lib/pages/account_settings_page.dart
+++ b/lib/pages/account_settings_page.dart
@@ -90,6 +90,11 @@ class _AccountSettingsPageState extends State<AccountSettingsPage> {
                 const SizedBox(height: 12),
                 ElevatedButton(
                   onPressed: null,
+                  child: const Text('Change Password'),
+                ),
+                const SizedBox(height: 12),
+                ElevatedButton(
+                  onPressed: null,
                   child: const Text('Delete My Account'),
                 ),
               ],


### PR DESCRIPTION
## Summary
- add a placeholder button for **Change Password** on the account settings page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d44e9c718832fa15333c7644d1f4b