### PR TITLE
Add active status update when disabling Unavailable

### DIFF
--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -440,11 +440,9 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
   Future<void> _toggleUnavailable(bool value) async {
     final data = <String, dynamic>{
       'unavailable': value,
+      'isActive': !value,
       'timestamp': DateTime.now(),
     };
-    if (value) {
-      data['isActive'] = false;
-    }
     try {
       await FirebaseFirestore.instance
           .collection('users')
@@ -462,10 +460,8 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
 
     setState(() {
       unavailable = value;
-      if (value) {
-        isActive = false;
-        status = 'Inactive';
-      }
+      isActive = !value;
+      status = isActive ? 'Active' : 'Inactive';
     });
 
     if (value) {
@@ -474,6 +470,9 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
       _showUnavailableBanner();
     } else {
       _hideUnavailableBanner();
+      if (isActive && _locationPermissionGranted) {
+        _startPositionUpdates();
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure `Temporarily Unavailable` toggle sets `isActive` depending on state
- restart location tracking when mechanic becomes available again

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687d4ca1189c832f9f27e2115ebc53ef