### PR TITLE
Add invoice service issue reports

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -1513,7 +1513,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
       subtitle: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('Invoice: ${data['invoiceId'] ?? ''}'),
+          Text('Invoice: ${data['relatedInvoiceId'] ?? data['invoiceId'] ?? ''}'),
           if (data['reportedBy'] != null)
             Text('Reported By: ${data['reportedBy']}'),
           if (preview.isNotEmpty) Text(shortText),

--- a/lib/pages/admin_report_detail_page.dart
+++ b/lib/pages/admin_report_detail_page.dart
@@ -46,10 +46,11 @@ class _AdminReportDetailPageState extends State<AdminReportDetailPage> {
     final data = doc.data();
     if (data == null) return null;
 
-    if (data['invoiceId'] != null) {
+    final invId = data['relatedInvoiceId'] ?? data['invoiceId'];
+    if (invId != null) {
       final invDoc = await FirebaseFirestore.instance
           .collection('invoices')
-          .doc(data['invoiceId'])
+          .doc(invId)
           .get();
       if (invDoc.exists) {
         data['invoiceNumber'] = invDoc.data()?['invoiceNumber'];
@@ -120,8 +121,8 @@ class _AdminReportDetailPageState extends State<AdminReportDetailPage> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text('Report ID: ${widget.reportId}'),
-          if (data['invoiceId'] != null)
-            Text('Invoice ID: ${data['invoiceId']}'),
+          if (data['relatedInvoiceId'] != null || data['invoiceId'] != null)
+            Text('Invoice ID: ${data['relatedInvoiceId'] ?? data['invoiceId']}'),
           if (data['reportedBy'] != null)
             Text('Reported By: ${data['reportedBy']}'),
           if ((data['reportText'] ?? '').toString().isNotEmpty)
@@ -135,14 +136,16 @@ class _AdminReportDetailPageState extends State<AdminReportDetailPage> {
           Wrap(
             spacing: 8,
             children: [
-              if (data['invoiceId'] != null)
+              if (data['relatedInvoiceId'] != null || data['invoiceId'] != null)
                 ElevatedButton(
                   onPressed: () {
+                    final invId =
+                        data['relatedInvoiceId'] ?? data['invoiceId'];
                     Navigator.push(
                       context,
                       MaterialPageRoute(
                         builder: (_) => AdminInvoiceDetailPage(
-                          invoiceId: data['invoiceId'],
+                          invoiceId: invId,
                           userId: widget.userId,
                         ),
                       ),

--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -318,7 +318,7 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
         return StatefulBuilder(
           builder: (context, setState) {
             return AlertDialog(
-              title: const Text('Report an Issue'),
+              title: const Text('Report Issue with This Service'),
               content: SingleChildScrollView(
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
@@ -395,14 +395,20 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
         await ref.putFile(_reportImage!);
         imageUrl = await ref.getDownloadURL();
       }
+      final uid = FirebaseAuth.instance.currentUser?.uid;
       await doc.set({
+        'reportText': _reportController.text.trim(),
+        'reportedBy': uid,
+        'role': widget.role,
+        'relatedInvoiceId': widget.invoiceId,
+        'type': 'service_issue',
+        'status': 'open',
+        'timestamp': FieldValue.serverTimestamp(),
+        if (imageUrl != null) 'imageUrl': imageUrl,
+        // legacy fields for backward compatibility
         'invoiceId': widget.invoiceId,
         'mechanicId': data['mechanicId'],
         'customerId': data['customerId'],
-        'reportText': _reportController.text.trim(),
-        'timestamp': FieldValue.serverTimestamp(),
-        'status': 'open',
-        if (imageUrl != null) 'imageUrl': imageUrl,
       });
       _reportController.clear();
       setState(() {
@@ -1532,7 +1538,7 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
               alignment: Alignment.centerRight,
               child: ElevatedButton(
                 onPressed: () => _showReportDialog(data),
-                child: const Text('Report an Issue'),
+                child: const Text('Report Issue with This Service'),
               ),
             ),
           );


### PR DESCRIPTION
## Summary
- allow customers and mechanics to file a service issue from the invoice detail page
- show related invoice id in admin pages
- store new fields for service issue reports in Firestore

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d4caaf66c832f873cbbec01681e7a