### PR TITLE
Add suspicious user handling

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -723,6 +723,32 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
     }
   }
 
+  Future<void> _markSuspicious(String userId) async {
+    await FirebaseFirestore.instance
+        .collection('users')
+        .doc(userId)
+        .update({'suspicious': true});
+    await _loadStats();
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('User marked suspicious')),
+      );
+    }
+  }
+
+  Future<void> _removeSuspicious(String userId) async {
+    await FirebaseFirestore.instance
+        .collection('users')
+        .doc(userId)
+        .update({'suspicious': false});
+    await _loadStats();
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Suspicious tag removed')),
+      );
+    }
+  }
+
   Future<void> _loadAppVersion() async {
     try {
       final info = await PackageInfo.fromPlatform();
@@ -1389,6 +1415,14 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
               },
               child: const Text('View History'),
             ),
+          TextButton(
+            onPressed: () => data['suspicious'] == true
+                ? _removeSuspicious(doc.id)
+                : _markSuspicious(doc.id),
+            child: Text(data['suspicious'] == true
+                ? 'Remove Suspicious Tag'
+                : 'Mark as Suspicious'),
+          ),
           _buildStatusBadges(data),
         ],
       ),
@@ -1597,6 +1631,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
             ),
             ...filteredDocs.map((d) {
               final data = d.data();
+              final suspicious = data['suspicious'] == true;
               return ListTile(
                 title: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -1654,6 +1689,14 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                       onPressed: () => _blockMechanic(d.id),
                       child: const Text('Block Mechanic'),
                     ),
+                    TextButton(
+                      onPressed: () => suspicious
+                          ? _removeSuspicious(d.id)
+                          : _markSuspicious(d.id),
+                      child: Text(suspicious
+                          ? 'Remove Suspicious Tag'
+                          : 'Mark as Suspicious'),
+                    ),
                   ],
                 ),
               );
@@ -1689,6 +1732,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
             ),
             ...filteredDocs.map((d) {
               final data = d.data();
+              final suspicious = data['suspicious'] == true;
               return ListTile(
                 title: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -1741,6 +1785,14 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                       onPressed: () => _unblockMechanic(d.id),
                       child: const Text('Unblock Mechanic'),
                     ),
+                    TextButton(
+                      onPressed: () => suspicious
+                          ? _removeSuspicious(d.id)
+                          : _markSuspicious(d.id),
+                      child: Text(suspicious
+                          ? 'Remove Suspicious Tag'
+                          : 'Mark as Suspicious'),
+                    ),
                   ],
                 ),
               );
@@ -1777,6 +1829,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
             ),
             ...filteredDocs.map((d) {
               final data = d.data();
+              final suspicious = data['suspicious'] == true;
               return ListTile(
                 title: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -1828,6 +1881,14 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                     TextButton(
                       onPressed: () => _unflagMechanic(d.id),
                       child: const Text('Remove Flag'),
+                    ),
+                    TextButton(
+                      onPressed: () => suspicious
+                          ? _removeSuspicious(d.id)
+                          : _markSuspicious(d.id),
+                      child: Text(suspicious
+                          ? 'Remove Suspicious Tag'
+                          : 'Mark as Suspicious'),
                     ),
                   ],
                 ),
@@ -1915,6 +1976,14 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                       onPressed: () => _unblockCustomer(d.id),
                       child: const Text('Unblock Customer'),
                     ),
+                    TextButton(
+                      onPressed: () => suspicious
+                          ? _removeSuspicious(d.id)
+                          : _markSuspicious(d.id),
+                      child: Text(suspicious
+                          ? 'Remove Suspicious Tag'
+                          : 'Mark as Suspicious'),
+                    ),
                   ],
                 ),
               );
@@ -1952,6 +2021,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
             ...filteredDocs.map((d) {
               final data = d.data();
               final flagged = data['flagged'] == true;
+              final suspicious = data['suspicious'] == true;
               return ListTile(
                 title: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -2002,6 +2072,14 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                     TextButton(
                       onPressed: flagged ? null : () => _flagCustomer(d.id),
                       child: const Text('Flag Customer'),
+                    ),
+                    TextButton(
+                      onPressed: () => suspicious
+                          ? _removeSuspicious(d.id)
+                          : _markSuspicious(d.id),
+                      child: Text(suspicious
+                          ? 'Remove Suspicious Tag'
+                          : 'Mark as Suspicious'),
                     ),
                   ],
                 ),
@@ -2089,6 +2167,14 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                     TextButton(
                       onPressed: () => _unflagCustomer(d.id),
                       child: const Text('Remove Flag'),
+                    ),
+                    TextButton(
+                      onPressed: () => suspicious
+                          ? _removeSuspicious(d.id)
+                          : _markSuspicious(d.id),
+                      child: Text(suspicious
+                          ? 'Remove Suspicious Tag'
+                          : 'Mark as Suspicious'),
                     ),
                   ],
                 ),

--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -42,6 +42,7 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
   bool _locationBannerVisible = false;
   bool _alertBannerVisible = false;
   bool _hasAccountData = true;
+  bool _suspicious = false;
   int availableMechanicCount = 0;
   bool _noMechanicsSnackbarShown = false;
   bool _requestAcceptedBannerVisible = false;
@@ -252,6 +253,9 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
       });
       return;
     }
+
+    final data = doc.data();
+    _suspicious = data?['suspicious'] == true;
 
     _loadWrenchIcon();
     _checkLocationPermissionOnLoad();
@@ -1292,6 +1296,24 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
                     )
                   : Stack(
               children: [
+                if (_suspicious)
+                  Positioned(
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    child: Container(
+                      padding: const EdgeInsets.all(8),
+                      color: Colors.red,
+                      child: const Text(
+                        '⚠️ Suspicious User',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
                 GoogleMap(
                   onMapCreated: _onMapCreated,
                   markers: markers,

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -52,6 +52,7 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
   StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _activeRequestsSub;
   bool _hasAccountData = true;
   bool _blocked = false;
+  bool _suspicious = false;
   int completedJobs = 0;
   bool unavailable = false;
 
@@ -327,6 +328,7 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
         });
         return;
       }
+      _suspicious = data['suspicious'] == true;
       setState(() {
         isActive = getBool(data, 'isActive');
         radiusMiles = (data['radiusMiles'] ?? 5).toDouble();
@@ -1049,6 +1051,21 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                 )
               : Column(
               children: [
+                if (_suspicious)
+                  Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(8),
+                    color: Colors.red,
+                    child: const Text(
+                      '⚠️ Suspicious User',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                if (_suspicious) const SizedBox(height: 8),
                 StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
                   stream: FirebaseFirestore.instance
                       .collection('invoices')
@@ -1164,11 +1181,21 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                     final data = snapshot.data?.data();
                     final completedCount = data?['completedJobs'] ?? completedJobs;
                     final blocked = data?['blocked'] == true;
+                    final suspicious = data?['suspicious'] == true;
                     if (blocked != _blocked) {
                       WidgetsBinding.instance.addPostFrameCallback((_) {
                         if (mounted) {
                           setState(() {
                             _blocked = blocked;
+                          });
+                        }
+                      });
+                    }
+                    if (suspicious != _suspicious) {
+                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                        if (mounted) {
+                          setState(() {
+                            _suspicious = suspicious;
                           });
                         }
                       });


### PR DESCRIPTION
## Summary
- allow admins to mark/unmark suspicious users from the dashboard
- track suspicious status in mechanic and customer dashboards
- show warning banners when account is marked suspicious

## Testing
- `dart` unavailable so formatting skipped

------
https://chatgpt.com/codex/tasks/task_e_687d4ef7f964832fa73b44b735e67eb0