### PR TITLE
Add customer feedback prompt after closing invoices

### DIFF
--- a/lib/pages/customer_request_history_page.dart
+++ b/lib/pages/customer_request_history_page.dart
@@ -122,7 +122,7 @@ class _CustomerRequestHistoryPageState extends State<CustomerRequestHistoryPage>
         'rating': rating,
         if (_feedbackController.text.trim().isNotEmpty)
           'feedbackText': _feedbackController.text.trim(),
-        'timestamp': FieldValue.serverTimestamp(),
+        'submittedAt': FieldValue.serverTimestamp(),
       });
     }
   }

--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -558,7 +558,7 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
         'rating': rating,
         if (_feedbackController.text.trim().isNotEmpty)
           'feedbackText': _feedbackController.text.trim(),
-        'timestamp': FieldValue.serverTimestamp(),
+        'submittedAt': FieldValue.serverTimestamp(),
       });
     }
   }
@@ -1552,6 +1552,34 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
                 onPressed: () => _showPaymentIssueDialog(data),
                 child: const Text('Report Payment Issue'),
               ),
+            ),
+          );
+        }
+
+        if (widget.role == 'customer' && invoiceStatus == 'closed') {
+          children.add(
+            FutureBuilder<QuerySnapshot<Map<String, dynamic>>>(
+              future: FirebaseFirestore.instance
+                  .collection('invoices')
+                  .doc(widget.invoiceId)
+                  .collection('feedback')
+                  .get(),
+              builder: (context, fbSnap) {
+                if (!fbSnap.hasData) {
+                  return const SizedBox.shrink();
+                }
+                final hasFb = fbSnap.data!.docs.isNotEmpty;
+                if (!hasFb) {
+                  return Align(
+                    alignment: Alignment.centerRight,
+                    child: TextButton(
+                      onPressed: () => _showFeedbackDialog(widget.invoiceId),
+                      child: const Text('Leave Feedback'),
+                    ),
+                  );
+                }
+                return const SizedBox.shrink();
+              },
             ),
           );
         }


### PR DESCRIPTION
## Summary
- support permanent feedback in `invoice_detail_page`
- allow customers to submit rating & comments once invoice is closed
- update feedback Firestore fields to use `submittedAt`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d4f0e20b4832f85f5e918106e242a