### PR TITLE
Add Firestore-based maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ firebase_options.dart
 - text
 - timestamp
 
-### system/config
-- maintenanceMode: `true` or `false`
-- maintenanceMessage: string
+### config/maintenance
+- enabled: `true` or `false`
+- message: string (optional)
 
 ## General Messaging & Support
 - Admin can message any user outside of invoices.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -101,18 +101,15 @@ class _MyAppState extends State<MyApp> {
 
   void _listenMaintenance() {
     _maintSub = FirebaseFirestore.instance
-        .collection('system')
-        .doc('config')
+        .collection('config')
+        .doc('maintenance')
         .snapshots()
         .listen((snap) {
       final data = snap.data();
-      if (data != null) {
-        setState(() {
-          _maintenanceMode = getBool(data, 'maintenanceMode');
-          _maintenanceMessage =
-              (data['maintenanceMessage'] ?? '').toString();
-        });
-      }
+      setState(() {
+        _maintenanceMode = getBool(data, 'enabled');
+        _maintenanceMessage = (data?['message'] ?? '').toString();
+      });
     });
   }
 

--- a/lib/pages/maintenance_mode_page.dart
+++ b/lib/pages/maintenance_mode_page.dart
@@ -19,8 +19,15 @@ class MaintenanceModePage extends StatelessWidget {
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 20),
-              Text(
-                message,
+              if (message.trim().isNotEmpty) ...[
+                Text(
+                  message,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 20),
+              ],
+              const Text(
+                'The app is currently unavailable. Please check back later.',
                 textAlign: TextAlign.center,
               ),
             ],


### PR DESCRIPTION
## Summary
- read maintenance config from `config/maintenance`
- show optional message and static notice while in maintenance mode
- update docs for new config path

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d52a9f450832fb832e0c2ddcf5b92