### PR TITLE
Add mechanic notifications

### DIFF
--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -678,10 +678,16 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
   }
 
   Widget _buildNotificationsIcon() {
-    return IconButton(
-      icon: const Icon(Icons.notifications),
-      tooltip: 'Notifications',
+    return TextButton.icon(
       onPressed: _openNotifications,
+      icon: Icon(
+        Icons.notifications,
+        color: Theme.of(context).colorScheme.onPrimary,
+      ),
+      label: Text(
+        'Notifications',
+        style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
+      ),
     );
   }
 

--- a/lib/pages/mechanic_notifications_page.dart
+++ b/lib/pages/mechanic_notifications_page.dart
@@ -18,9 +18,9 @@ class MechanicNotificationsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final stream = FirebaseFirestore.instance
-        .collection('notifications')
+        .collection('notifications_mechanics')
         .doc(userId)
-        .collection('messages')
+        .collection('notifications')
         .orderBy('timestamp', descending: true)
         .snapshots();
 
@@ -44,7 +44,7 @@ class MechanicNotificationsPage extends StatelessWidget {
               final doc = docs[index];
               final data = doc.data();
               final title = data['title'] ?? '';
-              final body = data['body'] ?? '';
+              final message = data['message'] ?? '';
               final Timestamp? ts = data['timestamp'];
               final bool read = getBool(data, 'read');
               return ListTile(
@@ -57,16 +57,28 @@ class MechanicNotificationsPage extends StatelessWidget {
                 subtitle: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    if (body.isNotEmpty) Text(body),
+                    if (message.isNotEmpty)
+                      Text(
+                        message,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
                     Text(_formatDate(ts)),
                   ],
                 ),
+                trailing: read
+                    ? null
+                    : const Icon(
+                        Icons.circle,
+                        size: 10,
+                        color: Colors.blue,
+                      ),
                 onTap: () {
                   if (!read) {
                     FirebaseFirestore.instance
-                        .collection('notifications')
+                        .collection('notifications_mechanics')
                         .doc(userId)
-                        .collection('messages')
+                        .collection('notifications')
                         .doc(doc.id)
                         .update({'read': true});
                   }


### PR DESCRIPTION
## Summary
- load mechanic notifications from `notifications_mechanics`
- show message preview and unread indicator
- show notifications button with label on mechanic dashboard

## Testing
- `dart` unavailable so formatting wasn't checked via dartfmt

------
https://chatgpt.com/codex/tasks/task_e_687d57839c08832fbf1ac612c9753e4e