### PR TITLE
Add tipping intent placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ SkipTow is currently open source for community contributions; it may become clos
 - View and manage all service requests, invoices and vehicle history
 - Receive push notifications for request updates and payment reminders
 - Report payment issues after confirming final price
+- Optionally tip your mechanic after confirming the final price (placeholder
+  payment processing)
 - Access a single support page for emergencies, FAQs and direct help
 - Manage profile, saved vehicles and account settings
 


### PR DESCRIPTION
## Summary
- add tipping intent prompt and record tip in Firestore
- show mechanic's intended tip on invoice detail
- document tipping placeholder in README

## Testing
- `dart format lib/pages/invoice_detail_page.dart README.md`

------
https://chatgpt.com/codex/tasks/task_e_687d57df0440832f9b9509abe14002c2