### PR TITLE
Add business blurb on login page for Stripe

### DIFF
--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -123,6 +123,12 @@ class _LoginPageState extends State<LoginPage> {
                   ?.copyWith(color: Colors.grey),
             ),
           ),
+          const SizedBox(height: 8),
+          Text(
+            'SkipTow connects vehicle owners with nearby mechanics for on-site repairs. Payments are processed securely through Stripe.',
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
         ],
       ),
     ),


### PR DESCRIPTION
## Summary
- add short description about SkipTow and Stripe payments at the bottom of the login page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e49bd1f60832f8d9efab14bc80679