### PR TITLE
Fix admin pages compile errors

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -1954,6 +1954,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
             ),
             ...filteredDocs.map((d) {
               final data = d.data();
+              final suspicious = data['suspicious'] == true;
               return ListTile(
                 title: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -2146,6 +2147,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
             ),
             ...filteredDocs.map((d) {
               final data = d.data();
+              final suspicious = data['suspicious'] == true;
               return ListTile(
                 title: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/pages/admin_user_detail_page.dart
+++ b/lib/pages/admin_user_detail_page.dart
@@ -232,7 +232,7 @@ class _AdminUserDetailPageState extends State<AdminUserDetailPage> {
                   Text(_isSuspicious ? 'Unmark Suspicious' : 'Mark as Suspicious Account'),
             ),
             const SizedBox(height: 20),
-          ];
+          ]);
 
           if (role == 'mechanic') {
             children.addAll([


### PR DESCRIPTION
## Summary
- close `children.addAll([...])` in admin user detail page
- define `suspicious` field when mapping over blocked and flagged customers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ea81d0588832faa90d44e702a9d4b