### PR TITLE
Fix hash helper usage

### DIFF
--- a/third_party/charts_flutter/lib/src/behaviors/chart_title/chart_title.dart
+++ b/third_party/charts_flutter/lib/src/behaviors/chart_title/chart_title.dart
@@ -22,7 +22,7 @@ import 'package:charts_common/common.dart' as common
         MaxWidthStrategy,
         OutsideJustification,
         TextStyleSpec;
-import '../../util/hash_helper.dart' show hashValues;
+import '../../util/hash_helper.dart' show hashAll, hashValues;
 import 'package:meta/meta.dart' show immutable;
 
 import '../chart_behavior.dart' show ChartBehavior, GestureType;
@@ -184,19 +184,20 @@ class ChartTitle<D> extends ChartBehavior<D> {
 
   @override
   int get hashCode {
-    return hashValues(
-        behaviorPosition,
-        layoutMinSize,
-        layoutPreferredSize,
-        maxWidthStrategy,
-        title,
-        titleDirection,
-        titleOutsideJustification,
-        titleStyleSpec,
-        subTitle,
-        subTitleStyleSpec,
-        innerPadding,
-        titlePadding,
-        outerPadding);
+    return hashAll([
+      behaviorPosition,
+      layoutMinSize,
+      layoutPreferredSize,
+      maxWidthStrategy,
+      title,
+      titleDirection,
+      titleOutsideJustification,
+      titleStyleSpec,
+      subTitle,
+      subTitleStyleSpec,
+      innerPadding,
+      titlePadding,
+      outerPadding,
+    ]);
   }
 }

--- a/third_party/charts_flutter/lib/src/behaviors/legend/datum_legend.dart
+++ b/third_party/charts_flutter/lib/src/behaviors/legend/datum_legend.dart
@@ -26,7 +26,7 @@ import 'package:charts_common/common.dart' as common
         SelectionModelType,
         TextStyleSpec;
 import 'package:flutter/widgets.dart' show BuildContext, EdgeInsets, Widget;
-import '../../util/hash_helper.dart' show hashValues;
+import '../../util/hash_helper.dart' show hashAll, hashValues;
 import 'package:meta/meta.dart' show immutable;
 import '../../chart_container.dart' show ChartContainerRenderObject;
 import '../chart_behavior.dart'
@@ -275,17 +275,18 @@ class DatumLegend<D> extends ChartBehavior<D> {
 
   @override
   int get hashCode {
-    return hashValues(
-        selectionModelType,
-        contentBuilder,
-        position,
-        outsideJustification,
-        insideJustification,
-        showMeasures,
-        legendDefaultMeasure,
-        measureFormatter,
-        secondaryMeasureFormatter,
-        entryTextStyle);
+    return hashAll([
+      selectionModelType,
+      contentBuilder,
+      position,
+      outsideJustification,
+      insideJustification,
+      showMeasures,
+      legendDefaultMeasure,
+      measureFormatter,
+      secondaryMeasureFormatter,
+      entryTextStyle,
+    ]);
   }
 }
 

--- a/third_party/charts_flutter/lib/src/behaviors/legend/series_legend.dart
+++ b/third_party/charts_flutter/lib/src/behaviors/legend/series_legend.dart
@@ -28,7 +28,7 @@ import 'package:charts_common/common.dart' as common
         TextStyleSpec;
 import 'package:collection/collection.dart' show ListEquality;
 import 'package:flutter/widgets.dart' show BuildContext, EdgeInsets, Widget;
-import '../../util/hash_helper.dart' show hashValues;
+import '../../util/hash_helper.dart' show hashAll, hashValues;
 import 'package:meta/meta.dart' show immutable;
 import '../../chart_container.dart' show ChartContainerRenderObject;
 import '../chart_behavior.dart'
@@ -288,18 +288,19 @@ class SeriesLegend<D> extends ChartBehavior<D> {
 
   @override
   int get hashCode {
-    return hashValues(
-        selectionModelType,
-        contentBuilder,
-        position,
-        outsideJustification,
-        insideJustification,
-        defaultHiddenSeries,
-        showMeasures,
-        legendDefaultMeasure,
-        measureFormatter,
-        secondaryMeasureFormatter,
-        entryTextStyle);
+    return hashAll([
+      selectionModelType,
+      contentBuilder,
+      position,
+      outsideJustification,
+      insideJustification,
+      defaultHiddenSeries,
+      showMeasures,
+      legendDefaultMeasure,
+      measureFormatter,
+      secondaryMeasureFormatter,
+      entryTextStyle,
+    ]);
   }
 }
 

--- a/third_party/charts_flutter/lib/src/util/hash_helper.dart
+++ b/third_party/charts_flutter/lib/src/util/hash_helper.dart
@@ -23,3 +23,11 @@ int hashValues(
     arg8,
   ]);
 }
+
+/// Helper to compute hash codes for an arbitrary number of values.
+///
+/// This mirrors the `hashList` utility from Flutter which wraps
+/// `Object.hashAll` but exposes a name consistent with [hashValues].
+int hashAll(Iterable<Object?> values) {
+  return Object.hashAll(values);
+}


### PR DESCRIPTION
## Summary
- update hash helper to support arbitrary value lists
- use new `hashAll` helper for legends and chart title

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_687eeda3c7d0832faf23558cf6877a09