### PR TITLE
Fix firebase function import for v1 API

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,4 +1,6 @@
-const functions = require('firebase-functions');
+// Use the v1 compat import since the code relies on the classic
+// firebase-functions API (e.g. functions.firestore.document()).
+const functions = require('firebase-functions/v1');
 const admin = require('firebase-admin');
 const stripe = require('stripe')(functions.config().stripe.secret);
 admin.initializeApp();


### PR DESCRIPTION
## Summary
- import `firebase-functions/v1` for compat API

This fixes runtime error `functions.firestore.document is not a function` during deployment.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f91257490832f98a4e61cf0ac48d9