### PR TITLE
Fix uni_links build error

### DIFF
--- a/packages/uni_links/android/src/main/java/name/avioli/unilinks/UniLinksPlugin.java
+++ b/packages/uni_links/android/src/main/java/name/avioli/unilinks/UniLinksPlugin.java
@@ -80,20 +80,11 @@ public class UniLinksPlugin
         eventChannel.setStreamHandler(plugin);
     }
 
-    /** Plugin registration. */
-    public static void registerWith(@NonNull PluginRegistry.Registrar registrar) {
-        // Detect if we've been launched in background
-        if (registrar.activity() == null) {
-            return;
-        }
-
-        final UniLinksPlugin instance = new UniLinksPlugin();
-        instance.context = registrar.context();
-        register(registrar.messenger(), instance);
-
-        instance.handleIntent(registrar.context(), registrar.activity().getIntent());
-        registrar.addNewIntentListener(instance);
-    }
+    /**
+     * Legacy plugin registration method removed to support newer Flutter
+     * Android embedding. The plugin now relies on automatic registration via
+     * the {@code pluginClass} setting in {@code pubspec.yaml}.
+     */
 
     @Override
     public void onDetachedFromEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {}


### PR DESCRIPTION
## Summary
- remove deprecated `registerWith` method from the local uni_links plugin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fab484ac8832f925bd392ccc0043c