### PR TITLE
Combine center and refresh buttons

### DIFF
--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -359,15 +359,6 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
     }
   }
 
-  void _centerMap() {
-    if (currentPosition != null) {
-      mapController?.animateCamera(
-        CameraUpdate.newLatLng(
-          LatLng(currentPosition!.latitude, currentPosition!.longitude),
-        ),
-      );
-    }
-  }
 
   Future<bool> _handleLocationPermission() async {
     final serviceEnabled = await Geolocator.isLocationServiceEnabled();
@@ -1473,25 +1464,14 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
                   child: _buildEtaOverlay(),
                 ),
                 Positioned(
-                  bottom: 16,
-                  left: 16,
-                  child: FloatingActionButton(
-                    heroTag: 'refresh_location_cust',
-                    tooltip: 'Refresh Location',
-                    mini: true,
-                    onPressed: _refreshLocation,
-                    child: const Icon(Icons.refresh),
-                  ),
-                ),
-                Positioned(
                   top: 10,
                   right: 10,
-                  child: FloatingActionButton.extended(
-                    heroTag: 'center_map_cust',
+                  child: FloatingActionButton(
+                    heroTag: 'center_refresh_cust',
                     tooltip: 'Center Map',
-                    label: const Text('Center Map'),
-                    icon: const Icon(Icons.my_location),
-                    onPressed: _centerMap,
+                    mini: true,
+                    onPressed: _refreshLocation,
+                    child: const Icon(Icons.my_location),
                   ),
                 ),
                 Positioned(

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -1483,24 +1483,13 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                       ),
                       Positioned(
                         bottom: 16,
-                        left: 16,
+                        right: 16,
                         child: FloatingActionButton(
-                          heroTag: 'refresh_location',
-                          tooltip: 'Refresh Location',
+                          heroTag: 'center_refresh_mech',
+                          tooltip: 'Center Map',
                           mini: true,
                           onPressed: _refreshLocation,
-                          child: const Icon(Icons.refresh),
-                        ),
-                      ),
-                      Positioned(
-                        bottom: 16,
-                        right: 16,
-                        child: FloatingActionButton.extended(
-                          heroTag: 'center_map_mech',
-                          tooltip: 'Center Map',
-                          label: const Text('Center Map'),
-                          icon: const Icon(Icons.my_location),
-                          onPressed: _centerMap,
+                          child: const Icon(Icons.my_location),
                         ),
                       ),
                     ],
@@ -1649,15 +1638,6 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
     super.dispose();
   }
 
-  void _centerMap() {
-    if (currentPosition != null) {
-      mapController?.animateCamera(
-        CameraUpdate.newLatLng(
-          LatLng(currentPosition!.latitude, currentPosition!.longitude),
-        ),
-      );
-    }
-  }
 
   Future<void> _refreshLocation() async {
     final hasPermission = await _handleLocationPermission();


### PR DESCRIPTION
## Summary
- merge the map refresh and center actions into a single button
- remove unused center map methods

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_68800ead7b84832fa9f3bd093b2fb91a