### PR TITLE
UI tweaks for navigation

### DIFF
--- a/lib/pages/customer_dashboard.dart
+++ b/lib/pages/customer_dashboard.dart
@@ -1251,123 +1251,127 @@ class _CustomerDashboardState extends State<CustomerDashboard> {
     return Scaffold(
       appBar: AppBar(
         title: const Text("Customer Map"),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.receipt_long),
-            tooltip: 'View My Requests',
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => ServiceRequestHistoryPage(
-                    userId: widget.userId,
-                  ),
-                ),
-              );
-            },
-          ),
-          TextButton.icon(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => CustomerInvoicesPage(
-                    userId: widget.userId,
-                  ),
-                ),
-              );
-            },
-            icon: Icon(
-              Icons.receipt,
-              color: Theme.of(context).colorScheme.onPrimary,
-            ),
-            label: Text(
-              'My Invoices',
-              style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
-            ),
-          ),
-          TextButton.icon(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => CustomerRequestHistoryPage(
-                    userId: widget.userId,
-                  ),
-                ),
-              );
-            },
-            icon: Icon(
-              Icons.history,
-              color: Theme.of(context).colorScheme.onPrimary,
-            ),
-            label: Text(
-              'Service History',
-              style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
-            ),
-          ),
-        TextButton.icon(
-          onPressed: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => CustomerProfilePage(
-                  userId: widget.userId,
-                ),
+      ),
+      drawer: Drawer(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: [
+            DrawerHeader(
+              decoration: BoxDecoration(
+                color: Theme.of(context).primaryColor,
               ),
-            );
-          },
-          icon: Icon(
-            Icons.person,
-            color: Theme.of(context).colorScheme.onPrimary,
-          ),
-          label: Text(
-            'Profile',
-            style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
-          ),
-        ),
-        TextButton.icon(
-          onPressed: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => const SettingsPage(),
+              child: const Text(
+                'Menu',
+                style: TextStyle(color: Colors.white, fontSize: 24),
               ),
-            );
-          },
-          icon: Icon(
-            Icons.settings,
-            color: Theme.of(context).colorScheme.onPrimary,
-          ),
-          label: Text(
-            'Account Settings',
-            style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
-          ),
+            ),
+            ListTile(
+              leading: const Icon(Icons.receipt_long),
+              title: const Text('View My Requests'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => ServiceRequestHistoryPage(
+                      userId: widget.userId,
+                    ),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.receipt),
+              title: const Text('My Invoices'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => CustomerInvoicesPage(
+                      userId: widget.userId,
+                    ),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.history),
+              title: const Text('Service History'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => CustomerRequestHistoryPage(
+                      userId: widget.userId,
+                    ),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.person),
+              title: const Text('Profile'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => CustomerProfilePage(
+                      userId: widget.userId,
+                    ),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.settings),
+              title: const Text('Account Settings'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const SettingsPage(),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.support_agent),
+              title: const Text('Help & Support'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => HelpSupportPage(
+                      userId: widget.userId,
+                      userRole: 'customer',
+                    ),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.mail),
+              title: const Text('Messages'),
+              onTap: () {
+                Navigator.pop(context);
+                _openMessages();
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.notifications),
+              title: const Text('Notifications'),
+              onTap: () {
+                Navigator.pop(context);
+                _openNotifications();
+              },
+            ),
+          ],
         ),
-        TextButton.icon(
-          onPressed: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => HelpSupportPage(
-                  userId: widget.userId,
-                  userRole: 'customer',
-                ),
-              ),
-            );
-          },
-          icon: Icon(
-            Icons.support_agent,
-            color: Theme.of(context).colorScheme.onPrimary,
-          ),
-          label: Text(
-            'Help & Support',
-            style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
-          ),
-        ),
-          _buildMessagesIcon(),
-          _buildNotificationsIcon(),
-        ],
       ),
       body: !_locationPermissionGranted
           ? const Center(

--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -97,12 +97,16 @@ class _DashboardPageState extends State<DashboardPage> {
         }
 
         return Scaffold(
-          body: dash,
-          floatingActionButtonLocation: FloatingActionButtonLocation.startFloat,
-          floatingActionButton: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
+          body: Stack(
             children: [
+              dash,
+              Positioned(
+                top: 16,
+                left: 16,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
               FloatingActionButton(
                 heroTag: 'refresh_button',
                 onPressed: () {
@@ -218,7 +222,10 @@ class _DashboardPageState extends State<DashboardPage> {
               ),
             ],
           ),
-        );
+        ),
+      ],
+    ),
+  );
       },
     );
   }

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -979,179 +979,200 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Mechanic Dashboard'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.receipt_long),
-            tooltip: 'View My Invoices',
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => InvoicesPage(userId: widget.userId),
-                ),
-              );
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.work_outline),
-            tooltip: 'Request Queue',
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => MechanicRequestsPage(
-                    mechanicId: widget.userId,
-                  ),
-                ),
-              );
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.inbox),
-            tooltip: 'Service Requests',
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => MechanicRequestQueuePage(
-                    mechanicId: widget.userId,
-                  ),
-                ),
-              );
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.history),
-            tooltip: 'Job History',
-            onPressed: _blocked
-                ? null
-                : () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => MechanicJobHistoryPage(
-                          mechanicId: widget.userId,
-                        ),
-                      ),
-                    );
-                  },
-          ),
-          IconButton(
-            icon: const Icon(Icons.bar_chart),
-            tooltip: 'Earnings Report',
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => MechanicEarningsReportPage(
-                    mechanicId: widget.userId,
-                  ),
-                ),
-              );
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.query_stats),
-            tooltip: 'Performance Stats',
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) =>
-                      MechanicPerformanceStatsPage(mechanicId: widget.userId),
-                ),
-              );
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.timeline),
-            tooltip: 'Radius History',
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) =>
-                      MechanicRadiusHistoryPage(mechanicId: widget.userId),
-                ),
-              );
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.location_searching),
-            tooltip: 'Location History',
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) =>
-                      MechanicLocationHistoryPage(mechanicId: widget.userId),
-                ),
-              );
-            },
-          ),
-          TextButton.icon(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => MechanicProfilePage(
-                    mechanicId: widget.userId,
-                    referral: false,
-                  ),
-                ),
-              );
-            },
-            icon: Icon(
-              Icons.person,
-              color: Theme.of(context).colorScheme.onPrimary,
-            ),
-            label: Text(
-              'Profile',
-              style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
-            ),
-          ),
-          TextButton.icon(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => const SettingsPage(),
-                ),
-              );
-            },
-            icon: Icon(
-              Icons.settings,
-              color: Theme.of(context).colorScheme.onPrimary,
-            ),
-          label: Text(
-            'Account Settings',
-            style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
-          ),
-        ),
-        TextButton.icon(
-          onPressed: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => HelpSupportPage(
-                  userId: widget.userId,
-                  userRole: 'mechanic',
-                ),
+      ),
+      drawer: Drawer(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: [
+            DrawerHeader(
+              decoration: BoxDecoration(
+                color: Theme.of(context).primaryColor,
               ),
-            );
-          },
-          icon: Icon(
-            Icons.support_agent,
-            color: Theme.of(context).colorScheme.onPrimary,
-          ),
-          label: Text(
-            'Help & Support',
-            style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
-          ),
+              child: const Text(
+                'Menu',
+                style: TextStyle(color: Colors.white, fontSize: 24),
+              ),
+            ),
+            ListTile(
+              leading: const Icon(Icons.receipt_long),
+              title: const Text('View My Invoices'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => InvoicesPage(userId: widget.userId),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.work_outline),
+              title: const Text('Request Queue'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => MechanicRequestsPage(
+                      mechanicId: widget.userId,
+                    ),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.inbox),
+              title: const Text('Service Requests'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => MechanicRequestQueuePage(
+                      mechanicId: widget.userId,
+                    ),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.history),
+              title: const Text('Job History'),
+              onTap: _blocked
+                  ? null
+                  : () {
+                      Navigator.pop(context);
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => MechanicJobHistoryPage(
+                            mechanicId: widget.userId,
+                          ),
+                        ),
+                      );
+                    },
+            ),
+            ListTile(
+              leading: const Icon(Icons.bar_chart),
+              title: const Text('Earnings Report'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => MechanicEarningsReportPage(
+                      mechanicId: widget.userId,
+                    ),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.query_stats),
+              title: const Text('Performance Stats'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) =>
+                        MechanicPerformanceStatsPage(mechanicId: widget.userId),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.timeline),
+              title: const Text('Radius History'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) =>
+                        MechanicRadiusHistoryPage(mechanicId: widget.userId),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.location_searching),
+              title: const Text('Location History'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) =>
+                        MechanicLocationHistoryPage(mechanicId: widget.userId),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.person),
+              title: const Text('Profile'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => MechanicProfilePage(
+                      mechanicId: widget.userId,
+                      referral: false,
+                    ),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.settings),
+              title: const Text('Account Settings'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const SettingsPage(),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.support_agent),
+              title: const Text('Help & Support'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => HelpSupportPage(
+                      userId: widget.userId,
+                      userRole: 'mechanic',
+                    ),
+                  ),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.mail),
+              title: const Text('Messages'),
+              onTap: () {
+                Navigator.pop(context);
+                _openMessages();
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.notifications),
+              title: const Text('Notifications'),
+              onTap: () {
+                Navigator.pop(context);
+                _openNotifications();
+              },
+            ),
+          ],
         ),
-        _buildMessagesIcon(),
-        _buildNotificationsIcon(),
-      ],
       ),
       body: _blocked
           ? const Center(


### PR DESCRIPTION
## Summary
- move dashboard floating buttons to the top-left on a stack
- convert mechanic dashboard buttons into a drawer menu
- convert customer dashboard buttons into a drawer menu

## Testing
- `python3 - <<'PY'
s=open('lib/pages/dashboard_page.dart').read().splitlines();stack=0
for l in s: stack+=l.count('('); stack-=l.count(')')
print('balance', stack)
PY`
- `python3 - <<'PY'
s=open('lib/pages/mechanic_dashboard.dart').read().splitlines();stack=0
for l in s: stack+=l.count('('); stack-=l.count(')')
print('balance', stack)
PY`
- `python3 - <<'PY'
s=open('lib/pages/customer_dashboard.dart').read().splitlines();stack=0
for l in s: stack+=l.count('('); stack-=l.count(')')
print('balance', stack)
PY`


------
https://chatgpt.com/codex/tasks/task_e_688122798204832f98e4628c1cc77655