### PR TITLE
Add pro subscription role tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ SkipTow is currently open source for community contributions; it may become clos
 - When `false` or missing the account is treated as a free tier user.
 
 ### Pro Onboarding Flow
-1. Navigate to **Settings** and tap **Upgrade to Pro - $10/month**.
+1. Navigate to **Settings** and tap **Subscribe to Pro - $10/month**.
 2. The app calls the `createProSubscriptionSession` cloud function to create a Stripe Checkout session.
 3. After payment on Stripe the user is redirected back to the success page.
 4. Server-side logic marks the account's `isProUser` field as `true` once the subscription is active.

--- a/functions/index.js
+++ b/functions/index.js
@@ -478,6 +478,8 @@ exports.createProSubscriptionSession = functions.https
 
       await admin.firestore().collection('users').doc(uid).update({
         subscriptionStatus: 'pending',
+        subscriptionRole: user.role || 'unknown',
+        stripeCustomerId: customer.id,
       });
 
       return { sessionId: session.id };
@@ -506,6 +508,7 @@ exports.stripeWebhook = functions.https.onRequest(async (req, res) => {
         isPro: true,
         isProUser: true,
         subscriptionStatus: 'active',
+        subscriptionRole: session.metadata?.userRole || 'unknown',
       };
       if (session.subscription) {
         update.stripeSubscriptionId = session.subscription;

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -187,7 +187,7 @@ class _SettingsPageState extends State<SettingsPage> {
                           height: 20,
                           child: CircularProgressIndicator(strokeWidth: 2),
                         )
-                      : const Text('Upgrade to Pro - $10/month'),
+                      : const Text('Subscribe to Pro - $10/month'),
                 )
             ] else ...[
               const Text('You have an active Pro subscription.'),


### PR DESCRIPTION
## Summary
- update onboarding docs to reference **Subscribe to Pro** wording
- rename Settings page button text so both customers and mechanics can "Subscribe to Pro"
- store subscription role and Stripe customer id in `createProSubscriptionSession`
- persist subscription role when webhook marks user as Pro

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68821cf84268832f9fec4cceef7c6df0