### PR TITLE
Fix invoiceStatus on status updates

### DIFF
--- a/lib/pages/admin_invoice_detail_page.dart
+++ b/lib/pages/admin_invoice_detail_page.dart
@@ -182,6 +182,7 @@ class _AdminInvoiceDetailPageState extends State<AdminInvoiceDetailPage> {
       'mechanicUsername': newUsername,
       'mechanicAccepted': false,
       'status': 'active',
+      'invoiceStatus': 'active',
       'reassignmentHistory': FieldValue.arrayUnion([
         {
           'mechanicId': mechanicId,
@@ -259,6 +260,7 @@ class _AdminInvoiceDetailPageState extends State<AdminInvoiceDetailPage> {
     final existing = await docRef.get();
     final updateData = {
       'invoiceStatus': 'closed',
+      'status': 'closed',
       'adminOverride': true,
     };
     if (existing.data()?['closedAt'] == null) {
@@ -308,6 +310,7 @@ class _AdminInvoiceDetailPageState extends State<AdminInvoiceDetailPage> {
         .doc(widget.invoiceId)
         .update({
       'invoiceStatus': 'cancelled',
+      'status': 'cancelled',
       'adminOverride': true,
     });
 

--- a/lib/pages/customer_request_history_page.dart
+++ b/lib/pages/customer_request_history_page.dart
@@ -371,7 +371,8 @@ class _CustomerRequestHistoryPageState extends State<CustomerRequestHistoryPage>
                                           .collection('invoices')
                                           .doc(doc.id)
                                           .update({
-                                        'invoiceStatus': 'cancelled'
+                                        'invoiceStatus': 'cancelled',
+                                        'status': 'cancelled'
                                       });
 
                                       if (context.mounted) {

--- a/lib/pages/invoice_detail_page.dart
+++ b/lib/pages/invoice_detail_page.dart
@@ -1292,6 +1292,7 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
                         'mechanicAcceptedAt': FieldValue.serverTimestamp(),
                         'acceptedAt': FieldValue.serverTimestamp(),
                         'status': 'accepted',
+                        'invoiceStatus': 'accepted',
                       });
                     });
                     if (context.mounted) {
@@ -1326,7 +1327,7 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
                   await FirebaseFirestore.instance
                       .collection('invoices')
                       .doc(widget.invoiceId)
-                      .update({'status': 'arrived'});
+                      .update({'status': 'arrived', 'invoiceStatus': 'arrived'});
 
                   if (mounted) {
                     ScaffoldMessenger.of(context).showSnackBar(
@@ -1352,7 +1353,7 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
                   await FirebaseFirestore.instance
                       .collection('invoices')
                       .doc(widget.invoiceId)
-                      .update({'status': 'in_progress'});
+                      .update({'status': 'in_progress', 'invoiceStatus': 'in_progress'});
 
                   if (mounted) {
                     ScaffoldMessenger.of(context).showSnackBar(
@@ -1539,6 +1540,7 @@ class _InvoiceDetailPageState extends State<InvoiceDetailPage> {
                         .doc(widget.invoiceId)
                         .update({
                       'status': 'cancelled',
+                      'invoiceStatus': 'cancelled',
                       'cancelledBy': 'mechanic',
                     });
 

--- a/lib/pages/invoices_page.dart
+++ b/lib/pages/invoices_page.dart
@@ -364,6 +364,7 @@ class _InvoiceTile extends StatelessWidget {
                       .doc(invoiceId)
                       .update({
                     'status': 'completed',
+                    'invoiceStatus': 'completed',
                     'finalPrice': price,
                     'postJobNotes': notes,
                     'platformFee': fee,
@@ -416,7 +417,7 @@ class _InvoiceTile extends StatelessWidget {
                 await FirebaseFirestore.instance
                     .collection('invoices')
                     .doc(invoiceId)
-                    .update({'status': 'cancelled'});
+                    .update({'status': 'cancelled', 'invoiceStatus': 'cancelled'});
 
                 if (context.mounted) {
                   ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -1946,6 +1946,7 @@ class _ActiveRequestCard extends StatelessWidget {
         final existing = await docRef.get();
         final updateData = {
           'status': 'completed',
+          'invoiceStatus': 'completed',
           'finalPrice': price,
           'postJobNotes': notes,
           'platformFee': fee,

--- a/lib/pages/mechanic_requests_page.dart
+++ b/lib/pages/mechanic_requests_page.dart
@@ -293,6 +293,7 @@ class _RequestCard extends StatelessWidget {
           'mechanicAcceptedAt': FieldValue.serverTimestamp(),
           'acceptedAt': FieldValue.serverTimestamp(),
           'status': 'accepted',
+          'invoiceStatus': 'accepted',
         });
       });
       if (context.mounted) {
@@ -364,6 +365,7 @@ class _RequestCard extends StatelessWidget {
       'mechanicAcceptedAt': FieldValue.serverTimestamp(),
       'acceptedAt': FieldValue.serverTimestamp(),
       'status': 'accepted',
+      'invoiceStatus': 'accepted',
     });
     if (context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -395,6 +397,7 @@ class _RequestCard extends StatelessWidget {
     if (confirmed != true) return;
     final update = <String, dynamic>{
       'status': 'cancelled',
+      'invoiceStatus': 'cancelled',
       'cancelledBy': 'mechanic',
     };
     if (data['mechanicResponded'] is List) {


### PR DESCRIPTION
## Summary
- keep invoiceStatus in sync with status when mechanics accept/cancel jobs
- propagate invoiceStatus updates for arrival/start/completed/cancelled
- sync admin/customer actions with invoiceStatus

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_688223b6077c832fae4c8edfdb2e2d4e