### PR TITLE
Add Stripe checkout success/cancel pages

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,8 @@ import 'pages/invoice_detail_page.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'pages/maintenance_mode_page.dart';
 import 'pages/mechanic_profile_page.dart';
+import 'pages/success_page.dart';
+import 'pages/cancel_page.dart';
 import 'deep_link_state.dart';
 
 void main() async {
@@ -249,6 +251,11 @@ class _MyAppState extends State<MyApp> {
         theme: lightTheme,
         darkTheme: darkTheme,
         themeMode: ThemeMode.system,
+        routes: {
+          '/': (context) => const LoginPage(),
+          '/success': (context) => const SuccessPage(),
+          '/cancel': (context) => const CancelPage(),
+        },
         home: const Scaffold(
           body: Center(child: CircularProgressIndicator()),
         ),
@@ -262,6 +269,11 @@ class _MyAppState extends State<MyApp> {
         theme: lightTheme,
         darkTheme: darkTheme,
         themeMode: ThemeMode.system,
+        routes: {
+          '/': (context) => const LoginPage(),
+          '/success': (context) => const SuccessPage(),
+          '/cancel': (context) => const CancelPage(),
+        },
         home: MaintenanceModePage(message: _maintenanceMessage),
       );
     }
@@ -272,6 +284,11 @@ class _MyAppState extends State<MyApp> {
       theme: lightTheme,
       darkTheme: darkTheme,
       themeMode: ThemeMode.system,
+      routes: {
+        '/': (context) => const LoginPage(),
+        '/success': (context) => const SuccessPage(),
+        '/cancel': (context) => const CancelPage(),
+      },
       home: _currentUserId != null
           ? DashboardPage(userId: _currentUserId!)
           : const LoginPage(),

--- a/lib/pages/cancel_page.dart
+++ b/lib/pages/cancel_page.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'dashboard_page.dart';
+
+class CancelPage extends StatelessWidget {
+  const CancelPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    Future.delayed(const Duration(seconds: 4), () {
+      final uid = FirebaseAuth.instance.currentUser?.uid;
+      if (uid != null && context.mounted) {
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(builder: (_) => DashboardPage(userId: uid)),
+        );
+      }
+    });
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Payment Canceled')),
+      body: const Center(
+        child: Text(
+          '❌ Payment canceled. Redirecting...',
+          style: TextStyle(fontSize: 18),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/success_page.dart
+++ b/lib/pages/success_page.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'dashboard_page.dart';
+
+class SuccessPage extends StatelessWidget {
+  const SuccessPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    Future.delayed(const Duration(seconds: 4), () {
+      final uid = FirebaseAuth.instance.currentUser?.uid;
+      if (uid != null && context.mounted) {
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(builder: (_) => DashboardPage(userId: uid)),
+        );
+      }
+    });
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Payment Success')),
+      body: const Center(
+        child: Text(
+          '✅ Subscription successful! Redirecting...',
+          style: TextStyle(fontSize: 18),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `SuccessPage` and `CancelPage` for Stripe Checkout flow
- map new pages in `MaterialApp` routes
- import new pages in `main.dart`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6882292da39c832fb0ef297c739b3cfe