### PR TITLE
Fix floating button overlay under app bar

### DIFF
--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -102,7 +102,8 @@ class _DashboardPageState extends State<DashboardPage> {
               dash,
               if (role != 'mechanic')
                 Positioned(
-                  top: 16,
+                  // Position buttons below the app bar
+                  top: MediaQuery.of(context).padding.top + kToolbarHeight + 16,
                   left: 16,
                   child: Column(
                     mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## Summary
- ensure floating buttons on DashboardPage appear below the app bar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688283549654832f9362a0fbefd10f1f