### PR TITLE
Fix Firestore message queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ firebase_options.dart
 7. Deploy Cloud Functions:
    - From the `functions` directory run `npm install`.
    - Deploy with `firebase deploy --only functions`.
+8. Create Firestore indexes:
+   - Ensure the `firestore.indexes.json` file is present in the project root.
+   - Deploy the indexes with `firebase deploy --only firestore:indexes`.
 
 ## Next Steps
 - Payment processing integration

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,30 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "fromUserId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "toUserId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "fromUserId", "order": "ASCENDING" },
+        { "fieldPath": "toUserId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/lib/pages/messages_page.dart
+++ b/lib/pages/messages_page.dart
@@ -142,6 +142,9 @@ class _MessagesPageState extends State<MessagesPage> {
     return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
       stream: query.snapshots(),
       builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return const Center(child: Text('Error loading messages'));
+        }
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator());
         }
@@ -221,6 +224,9 @@ class _MessagesPageState extends State<MessagesPage> {
           child: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
             stream: query.snapshots(),
             builder: (context, snapshot) {
+              if (snapshot.hasError) {
+                return const Center(child: Text('Error loading messages'));
+              }
               if (!snapshot.hasData) {
                 return const Center(child: CircularProgressIndicator());
               }


### PR DESCRIPTION
## Summary
- add missing Firestore composite indexes for message queries
- show an error in MessagesPage when snapshot errors occur
- document how to deploy indexes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882802ccea8832fac94814189ceea74