### PR TITLE
Remove dark theme functionality

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -236,19 +236,11 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     final ThemeData lightTheme =
         ThemeData(colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange));
-    final ThemeData darkTheme = ThemeData(
-      colorScheme: ColorScheme.fromSeed(
-        seedColor: Colors.orange,
-        brightness: Brightness.dark,
-      ),
-    );
 
     if (_loading || _maintenanceMode == null) {
       return MaterialApp(
         navigatorKey: navigatorKey,
         theme: lightTheme,
-        darkTheme: darkTheme,
-        themeMode: ThemeMode.system,
         routes: {
           '/': (context) => const LoginPage(),
           '/success': (context) => const SuccessPage(),
@@ -265,8 +257,6 @@ class _MyAppState extends State<MyApp> {
         title: 'SkipTow',
         debugShowCheckedModeBanner: false,
         theme: lightTheme,
-        darkTheme: darkTheme,
-        themeMode: ThemeMode.system,
         routes: {
           '/': (context) => const LoginPage(),
           '/success': (context) => const SuccessPage(),
@@ -280,8 +270,6 @@ class _MyAppState extends State<MyApp> {
       title: 'SkipTow',
       debugShowCheckedModeBanner: false,
       theme: lightTheme,
-      darkTheme: darkTheme,
-      themeMode: ThemeMode.system,
       routes: {
         '/': (context) => const LoginPage(),
         '/success': (context) => const SuccessPage(),

--- a/windows/runner/win32_window.cpp
+++ b/windows/runner/win32_window.cpp
@@ -18,13 +18,6 @@ namespace {
 
 constexpr const wchar_t kWindowClassName[] = L"FLUTTER_RUNNER_WIN32_WINDOW";
 
-/// Registry key for app theme preference.
-///
-/// A value of 0 indicates apps should use dark mode. A non-zero or missing
-/// value indicates apps should use light mode.
-constexpr const wchar_t kGetPreferredBrightnessRegKey[] =
-  L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
-constexpr const wchar_t kGetPreferredBrightnessRegValue[] = L"AppsUseLightTheme";
 
 // The number of Win32Window objects that currently exist.
 static int g_active_window_count = 0;
@@ -273,16 +266,8 @@ void Win32Window::OnDestroy() {
 }
 
 void Win32Window::UpdateTheme(HWND const window) {
-  DWORD light_mode;
-  DWORD light_mode_size = sizeof(light_mode);
-  LSTATUS result = RegGetValue(HKEY_CURRENT_USER, kGetPreferredBrightnessRegKey,
-                               kGetPreferredBrightnessRegValue,
-                               RRF_RT_REG_DWORD, nullptr, &light_mode,
-                               &light_mode_size);
-
-  if (result == ERROR_SUCCESS) {
-    BOOL enable_dark_mode = light_mode == 0;
-    DwmSetWindowAttribute(window, DWMWA_USE_IMMERSIVE_DARK_MODE,
-                          &enable_dark_mode, sizeof(enable_dark_mode));
-  }
+  // Always use light window decorations.
+  BOOL enable_dark_mode = FALSE;
+  DwmSetWindowAttribute(window, DWMWA_USE_IMMERSIVE_DARK_MODE,
+                        &enable_dark_mode, sizeof(enable_dark_mode));
 }

--- a/windows/runner/win32_window.h
+++ b/windows/runner/win32_window.h
@@ -87,7 +87,8 @@ class Win32Window {
   // Retrieves a class instance pointer for |window|
   static Win32Window* GetThisFromHandle(HWND const window) noexcept;
 
-  // Update the window frame's theme to match the system theme.
+  // Update the window frame's theme. This implementation always uses
+  // a light appearance.
   static void UpdateTheme(HWND const window);
 
   bool quit_on_close_ = false;


### PR DESCRIPTION
## Summary
- delete unused dark theme in the Flutter app
- always disable dark mode decorations on Windows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884e9b606c4832fb11678e7c41d749e