### PR TITLE
Fix pending mechanic redirect after login

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,6 +76,23 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
+/// Navigate to a mechanic profile if a referral deep link was opened
+/// before authentication.
+void processPendingRedirect() {
+  final id = pendingRedirectMechanicId;
+  if (id != null) {
+    pendingRedirectMechanicId = null;
+    navigatorKey.currentState?.push(
+      MaterialPageRoute(
+        builder: (_) => MechanicProfilePage(
+          mechanicId: id,
+          referral: true,
+        ),
+      ),
+    );
+  }
+}
+
 class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
@@ -151,6 +168,7 @@ class _MyAppState extends State<MyApp> {
           _currentUserId = user.uid;
         });
         _pushService.registerDevice(user.uid);
+        processPendingRedirect();
       }
     });
     setState(() { _loading = false; });

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -9,7 +9,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import '../deep_link_state.dart';
 import 'mechanic_profile_page.dart';
-import 'package:skiptow/main.dart' show navigatorKey;
+import 'package:skiptow/main.dart' show navigatorKey, processPendingRedirect;
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -60,18 +60,7 @@ class _LoginPageState extends State<LoginPage> {
           context,
           MaterialPageRoute(builder: (_) => DashboardPage(userId: user.uid)),
         );
-        if (pendingRedirectMechanicId != null) {
-          final mechId = pendingRedirectMechanicId!;
-          pendingRedirectMechanicId = null;
-          navigatorKey.currentState?.push(
-            MaterialPageRoute(
-              builder: (_) => MechanicProfilePage(
-                mechanicId: mechId,
-                referral: true,
-              ),
-            ),
-          );
-        }
+        processPendingRedirect();
       } else {
         _status = 'No user ID found';
       }


### PR DESCRIPTION
## Summary
- add a global `processPendingRedirect` helper to navigate to a mechanic profile after authentication
- invoke this helper when auth state changes
- reuse helper in login flow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884ea7212ac832f939c1a5ddd74cefc