### PR TITLE
Fix push notification token on logout

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -16,6 +16,7 @@ import 'admin_customer_history_page.dart';
 import 'admin_broadcast_message_page.dart';
 import 'admin_report_detail_page.dart';
 import 'admin_message_center_page.dart';
+import 'package:skiptow/services/push_notification_service.dart';
 
 /// Simple admin dashboard for monitoring the platform.
 class AdminDashboardPage extends StatefulWidget {
@@ -763,6 +764,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
   }
 
   Future<void> _logout() async {
+    await PushNotificationService().unregisterDevice(widget.userId);
     await FirebaseAuth.instance.signOut();
     await const FlutterSecureStorage().delete(key: 'session_token');
     if (mounted) {

--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -10,6 +10,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'help_support_page.dart';
 import 'jobs_page.dart';
 import 'vehicle_history_page.dart';
+import 'package:skiptow/services/push_notification_service.dart';
 
 class DashboardPage extends StatefulWidget {
   final String userId;
@@ -34,6 +35,7 @@ class _DashboardPageState extends State<DashboardPage> {
   }
 
   void _logout(BuildContext context) async {
+    await PushNotificationService().unregisterDevice(widget.userId);
     await FirebaseAuth.instance.signOut();
     await const FlutterSecureStorage().delete(key: 'session_token');
     // Reset snackbar flag so message shows on next login

--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -12,6 +12,7 @@ import 'package:qr_flutter/qr_flutter.dart';
 import 'package:share_plus/share_plus.dart';
 import '../services/image_downloader.dart';
 import 'package:intl/intl.dart';
+import 'package:skiptow/services/push_notification_service.dart';
 import 'invoices_page.dart';
 import 'messages_page.dart';
 import 'jobs_page.dart';
@@ -1457,6 +1458,10 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
   }
 
   Future<void> _logout() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user != null) {
+      await PushNotificationService().unregisterDevice(user.uid);
+    }
     await FirebaseAuth.instance.signOut();
     await const FlutterSecureStorage().delete(key: 'session_token');
     if (mounted) {

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -7,6 +7,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'mechanic_qr_page.dart';
+import 'package:skiptow/services/push_notification_service.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
@@ -89,6 +90,10 @@ class _SettingsPageState extends State<SettingsPage> {
   }
 
   Future<void> _logout() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user != null) {
+      await PushNotificationService().unregisterDevice(user.uid);
+    }
     await FirebaseAuth.instance.signOut();
     if (mounted) {
       Navigator.pushAndRemoveUntil(

--- a/lib/services/push_notification_service.dart
+++ b/lib/services/push_notification_service.dart
@@ -47,6 +47,22 @@ class PushNotificationService {
     });
   }
 
+  /// Removes the current device token for the given user in Firestore
+  /// and attempts to delete it from Firebase Messaging.
+  Future<void> unregisterDevice(String userId) async {
+    final token = await _messaging.getToken();
+    if (token == null) return;
+    final ref = FirebaseFirestore.instance
+        .collection('users')
+        .doc(userId)
+        .collection('tokens')
+        .doc(token);
+    await ref.delete();
+    try {
+      await _messaging.deleteToken();
+    } catch (_) {}
+  }
+
   /// Display the notification locally when received.
   Future<void> handleMessage(RemoteMessage message) async {
     final notification = message.notification;


### PR DESCRIPTION
## Summary
- add method to unregister a device token
- remove device token on logout from admin, mechanic, settings, and dashboard pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884ea99b434832fafdd2b78fdd29732