### PR TITLE
Fix app label

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
     <application
-        android:label="skiptow"
+        android:label="SkipTow"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/web/index.html
+++ b/web/index.html
@@ -26,13 +26,13 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="skiptow">
+  <meta name="apple-mobile-web-app-title" content="SkipTow">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>skiptow</title>
+  <title>SkipTow</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "skiptow",
-    "short_name": "skiptow",
+    "name": "SkipTow",
+    "short_name": "SkipTow",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",


### PR DESCRIPTION
## Summary
- correct Android app label to `SkipTow`
- display `SkipTow` in browser tab and PWA manifest

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68850d02a5fc832f8058cc58dbaae3bf