### PR TITLE
Stop redirect to jobs page on activate

### DIFF
--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -511,15 +511,10 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
       backgroundTimer?.cancel();
     }
 
-    // Navigate to the jobs page when activating
-    if (goingActive && mounted) {
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (_) => JobsPage(userId: widget.userId),
-        ),
-      );
-    }
+    // No automatic navigation when activating; mechanic stays on dashboard
+    // Previously the app redirected to the jobs page when the mechanic
+    // toggled active. This behavior has been removed so mechanics can
+    // remain on the dashboard after going active.
   }
 
   Future<void> _toggleUnavailable(bool value) async {


### PR DESCRIPTION
## Summary
- keep mechanics on the dashboard when toggling active

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_68850d5a545c832f91f4c086fd11039c