### PR TITLE
Combine mechanic history views

### DIFF
--- a/lib/pages/mechanic_dashboard.dart
+++ b/lib/pages/mechanic_dashboard.dart
@@ -20,8 +20,7 @@ import 'mechanic_profile_page.dart';
 import 'settings_page.dart';
 import 'mechanic_earnings_report_page.dart';
 import 'mechanic_notifications_page.dart';
-import 'mechanic_radius_history_page.dart';
-import 'mechanic_location_history_page.dart';
+import 'mechanic_history_page.dart';
 import 'help_support_page.dart';
 import 'mechanic_performance_stats_page.dart';
 import '../services/alert_service.dart';
@@ -1042,20 +1041,6 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
               },
             ),
             ListTile(
-              leading: const Icon(Icons.timeline),
-              title: const Text('Radius History'),
-              onTap: () {
-                Navigator.pop(context);
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) =>
-                        MechanicRadiusHistoryPage(mechanicId: widget.userId),
-                  ),
-                );
-              },
-            ),
-            ListTile(
               leading: const Icon(Icons.location_searching),
               title: const Text('Location History'),
               onTap: () {
@@ -1064,7 +1049,7 @@ class _MechanicDashboardState extends State<MechanicDashboard> {
                   context,
                   MaterialPageRoute(
                     builder: (_) =>
-                        MechanicLocationHistoryPage(mechanicId: widget.userId),
+                        MechanicHistoryPage(mechanicId: widget.userId),
                   ),
                 );
               },

--- a/lib/pages/mechanic_history_page.dart
+++ b/lib/pages/mechanic_history_page.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:intl/intl.dart';
+import '../utils.dart';
+
+/// Combined history page for mechanics showing location and radius history.
+class MechanicHistoryPage extends StatelessWidget {
+  final String mechanicId;
+  const MechanicHistoryPage({super.key, required this.mechanicId});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Location History'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Location'),
+              Tab(text: 'Radius'),
+            ],
+          ),
+        ),
+        body: TabBarView(
+          children: [
+            _LocationHistoryTab(mechanicId: mechanicId),
+            _RadiusHistoryTab(mechanicId: mechanicId),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _LocationHistoryTab extends StatelessWidget {
+  final String mechanicId;
+  const _LocationHistoryTab({required this.mechanicId});
+
+  @override
+  Widget build(BuildContext context) {
+    final stream = FirebaseFirestore.instance
+        .collection('mechanics')
+        .doc(mechanicId)
+        .collection('location_history')
+        .orderBy('timestamp', descending: true)
+        .snapshots();
+
+    return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+      stream: stream,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        final docs = snapshot.data?.docs ?? [];
+        if (docs.isEmpty) {
+          return const Center(child: Text('No location history found'));
+        }
+
+        final rows = docs.map((doc) {
+          final data = doc.data();
+          final ts = data['timestamp'];
+          final dt = ts is Timestamp ? ts.toDate().toLocal() : DateTime.now();
+          final lat = (data['lat'] as num?)?.toDouble();
+          final lng = (data['lng'] as num?)?.toDouble();
+          return DataRow(cells: [
+            DataCell(Text(DateFormat('MMM d, yyyy h:mm a').format(dt))),
+            DataCell(Text(lat?.toStringAsFixed(6) ?? '')),
+            DataCell(Text(lng?.toStringAsFixed(6) ?? '')),
+          ]);
+        }).toList();
+
+        return SingleChildScrollView(
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: DataTable(
+              columns: const [
+                DataColumn(label: Text('Date/Time')),
+                DataColumn(label: Text('Latitude')),
+                DataColumn(label: Text('Longitude')),
+              ],
+              rows: rows,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _RadiusHistoryTab extends StatelessWidget {
+  final String mechanicId;
+  const _RadiusHistoryTab({required this.mechanicId});
+
+  @override
+  Widget build(BuildContext context) {
+    final stream = FirebaseFirestore.instance
+        .collection('mechanics')
+        .doc(mechanicId)
+        .collection('radius_history')
+        .orderBy('timestamp', descending: true)
+        .snapshots();
+
+    return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+      stream: stream,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        final docs = snapshot.data?.docs ?? [];
+        if (docs.isEmpty) {
+          return const Center(child: Text('No radius changes found'));
+        }
+
+        return ListView.builder(
+          itemCount: docs.length,
+          itemBuilder: (context, index) {
+            final data = docs[index].data();
+            final radius = (data['newRadiusMiles'] as num?)?.toDouble() ?? 0.0;
+            final ts = data['timestamp'] as Timestamp?;
+            return ListTile(
+              leading: const Icon(Icons.radio_button_checked),
+              title: Text('Radius: ${radius.toStringAsFixed(0)} miles'),
+              subtitle: Text(formatDate(ts)),
+            );
+          },
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a consolidated `MechanicHistoryPage` with tabs for location and radius history
- update mechanic dashboard menu to open new history page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688511d908e4832f93b96ca76928083b