### PR TITLE
Fix const usage in payment processing page

### DIFF
--- a/lib/pages/payment_processing_page.dart
+++ b/lib/pages/payment_processing_page.dart
@@ -46,9 +46,9 @@ class _PaymentProcessingPageState extends State<PaymentProcessingPage> {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      appBar: AppBar(title: Text('Payment')),
-      body: Center(
+    return Scaffold(
+      appBar: AppBar(title: const Text('Payment')),
+      body: const Center(
         child: CircularProgressIndicator(),
       ),
     );


### PR DESCRIPTION
## Summary
- remove const constructor from Scaffold in PaymentProcessingPage
- keep Text and CircularProgressIndicator widgets const

This resolves a dart2js compilation error complaining about invoking a non-const constructor in a const context.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885261f6014832fa199088e642a980e