### PR TITLE
Fix admin chat threads

### DIFF
--- a/lib/pages/admin_dashboard.dart
+++ b/lib/pages/admin_dashboard.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../services/admin_config.dart';
 import 'dart:async';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -800,7 +801,7 @@ class _AdminDashboardPageState extends State<AdminDashboardPage> {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (_) => AdminMessageCenterPage(adminId: widget.userId),
+                    builder: (_) => const AdminMessageCenterPage(),
                   ),
                 );
               },

--- a/lib/pages/admin_message_center_page.dart
+++ b/lib/pages/admin_message_center_page.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
+import '../services/admin_config.dart';
 import 'general_chat_page.dart';
 
 /// Page for admins to manage general message threads with any user.
 class AdminMessageCenterPage extends StatelessWidget {
   final String adminId;
-  const AdminMessageCenterPage({super.key, required this.adminId});
+  const AdminMessageCenterPage({super.key, this.adminId = kSupportAdminId});
 
   Future<void> _startNewChat(BuildContext context) async {
     final controller = TextEditingController();

--- a/lib/pages/help_support_page.dart
+++ b/lib/pages/help_support_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:url_launcher/url_launcher.dart';
+import '../services/admin_config.dart';
 import 'general_chat_page.dart';
 import 'terms_and_conditions_page.dart';
 
@@ -19,8 +20,7 @@ class HelpSupportPage extends StatelessWidget {
   /// function can be updated to perform a query instead.
   Future<String?> _getAdminId() async {
     // Directly return the known admin user id.
-    const adminId = 'HvTwsJCasRZUIl2hXBzxmVyhLLL2';
-    return adminId;
+    return kSupportAdminId;
   }
 
   Future<String?> _getUsername(String id) async {

--- a/lib/services/admin_config.dart
+++ b/lib/services/admin_config.dart
@@ -1,0 +1,1 @@
+const String kSupportAdminId = 'HvTwsJCasRZUIl2hXBzxmVyhLLL2';


### PR DESCRIPTION
## Summary
- centralize the support admin id in `admin_config.dart`
- use `kSupportAdminId` in `HelpSupportPage`
- make `AdminMessageCenterPage` default to that admin id
- open the admin message center with the constant id

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688551c2b410832f9dc493b684fa4cdd